### PR TITLE
feat: add waveform-first music console

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,8 @@
         "lucide-react": "^0.511.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "tailwind-merge": "^2.5.5"
+        "tailwind-merge": "^2.5.5",
+        "wavesurfer.js": "^7.12.5"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",
@@ -3238,6 +3239,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/wavesurfer.js": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.12.5.tgz",
+      "integrity": "sha512-MSZcA13R9ZlxgYpzfakaSYf8dz5tCdZKYbjtN1qnKbCi+UoyfaTuhvjlXHrITi/fgeO3qWfsH7U3BP1AKnwRNg==",
+      "license": "BSD-3-Clause"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "lucide-react": "^0.511.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "tailwind-merge": "^2.5.5"
+    "tailwind-merge": "^2.5.5",
+    "wavesurfer.js": "^7.12.5"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,10 @@
-import { startTransition, useEffect, useRef, useState } from "react";
+import { startTransition, useCallback, useEffect, useRef, useState } from "react";
 import {
   Activity,
   BarChart3,
   Clock3,
   Disc3,
   Music2,
-  Pause,
-  Play,
   Search,
   Sparkles,
   Upload,
@@ -29,6 +27,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { WaveformConsole } from "@/components/music/waveform-console";
 
 function formatDuration(durationSeconds?: number | null) {
   if (!durationSeconds) {
@@ -110,6 +109,8 @@ function App() {
   const [analysisStatus, setAnalysisStatus] = useState<AnalysisStatusResponse | null>(null);
   const [analysisLoading, setAnalysisLoading] = useState(false);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
+  const [previewPositionSeconds, setPreviewPositionSeconds] = useState(0);
+  const [previewPlaying, setPreviewPlaying] = useState(false);
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
 
   const refreshState = async () => {
@@ -221,6 +222,8 @@ function App() {
       setAnalysisStatus(null);
       setAnalysisError(null);
       setAnalysisLoading(false);
+      setPreviewPositionSeconds(0);
+      setPreviewPlaying(false);
       return;
     }
 
@@ -300,7 +303,7 @@ function App() {
     : "No song selected";
   const bpm = analysis ? analysis.bpm : (state?.transport.bpm ?? 120);
   const energy = analysis ? average(analysis.energy.rms) : (state?.transport.energy ?? 0.5);
-  const positionSeconds = state?.transport.position_seconds ?? 0;
+  const positionSeconds = currentTrack ? previewPositionSeconds : (state?.transport.position_seconds ?? 0);
   const analysisFrameIndex = analysis ? Math.floor(positionSeconds * analysis.energy.frame_hz) : 0;
   const waveformBars = analysis
     ? downsample(analysis.waveform.peaks, 56).map((value) => Math.round(14 + value * 86))
@@ -310,6 +313,33 @@ function App() {
   const highBandValue = analysis ? sampleSeries(analysis.bands.high, analysisFrameIndex) : 0;
   const activeSection = analysis ? currentSection(analysis.sections, positionSeconds) : null;
   const cueSummary = choreography ?? analysis?.choreography ?? null;
+  const transportPlaying = currentTrack ? previewPlaying : (state?.transport.playing ?? false);
+
+  const syncTransportPlayback = useCallback(
+    async (playing: boolean) => {
+      if (!currentTrack) {
+        setPreviewPlaying(false);
+        return;
+      }
+
+      setPreviewPlaying(playing);
+
+      try {
+        const next = await setTransport({
+          track_name: `${currentTrack.title} - ${currentTrack.artist}`,
+          bpm,
+          energy,
+          playing,
+        });
+        startTransition(() => {
+          setState(next);
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unable to update transport");
+      }
+    },
+    [bpm, currentTrack, energy],
+  );
 
   return (
     <main className="relative min-h-screen overflow-hidden px-4 py-6 sm:px-6 lg:px-10">
@@ -321,7 +351,7 @@ function App() {
               <div className="flex flex-wrap items-center gap-3">
                 <Badge>Music Search</Badge>
                 <Badge variant="muted">Song-First Interface</Badge>
-                <Badge variant="accent">{state?.transport.playing ? "Transport Live" : "Waiting on Selection"}</Badge>
+                <Badge variant="accent">{transportPlaying ? "Transport Live" : "Waiting on Selection"}</Badge>
               </div>
 
               <div className="mt-6 max-w-3xl space-y-4">
@@ -437,7 +467,7 @@ function App() {
                     </p>
                   </div>
                   <div className="rounded-full border border-white/10 bg-black/20 px-4 py-2 text-sm text-slate-300">
-                    {state?.transport.playing ? "Playing" : "Paused"}
+                    {transportPlaying ? "Playing" : "Paused"}
                   </div>
                 </div>
 
@@ -448,41 +478,23 @@ function App() {
                 </div>
 
                 <div className="mt-8 rounded-[28px] border border-white/10 bg-black/25 p-5">
-                  <div className="flex items-center justify-between gap-4">
+                  <div className="flex flex-wrap items-center justify-between gap-4">
                     <div>
-                      <p className="hud-label">Transport</p>
+                      <p className="hud-label">Waveform Workflow</p>
                       <p className="mt-2 text-lg font-medium text-white">
-                        {currentTrack ? "Preview and inspect the song before robot integration." : "No preview loaded"}
+                        {currentTrack ? "Preview is now centered in the waveform console below." : "No preview loaded"}
                       </p>
                     </div>
-                    <Button
-                      variant="secondary"
-                      onClick={() =>
-                        currentTrack
-                          ? void commitAction(() =>
-                              setTransport({
-                                track_name: state?.transport.track_name ?? `${currentTrack.title} - ${currentTrack.artist}`,
-                                bpm,
-                                energy,
-                                playing: !state?.transport.playing,
-                              }),
-                            )
-                          : undefined
-                      }
-                      disabled={!currentTrack}
-                    >
-                      {state?.transport.playing ? <Pause className="mr-2 h-4 w-4" /> : <Play className="mr-2 h-4 w-4" />}
-                      {state?.transport.playing ? "Pause" : "Play"}
-                    </Button>
+                    <div className="flex flex-wrap gap-3">
+                      <TrackChip label="Preview" value={currentTrack?.audio_url ? "wavesurfer" : "unavailable"} />
+                      <TrackChip label="Markers" value={analysis ? `${analysis.beats.length} beats` : "pending"} />
+                      <TrackChip label="Sections" value={analysis ? `${analysis.sections.length}` : "pending"} />
+                    </div>
                   </div>
-
-                  {currentTrack?.audio_url ? (
-                    <audio controls preload="none" src={currentTrack.audio_url} className="mt-5 w-full opacity-90" />
-                  ) : (
-                    <p className="mt-5 text-sm text-slate-400">
-                      The selected track has no preview URL yet, but its motion profile is still available.
-                    </p>
-                  )}
+                  <p className="mt-5 text-sm text-slate-400">
+                    Use the waveform console to play, pause, scrub, and inspect beat markers before the robot layer is
+                    attached.
+                  </p>
                 </div>
               </div>
 
@@ -500,6 +512,15 @@ function App() {
             </CardContent>
           </Card>
         </section>
+
+        <WaveformConsole
+          track={currentTrack}
+          analysis={analysis}
+          currentTime={positionSeconds}
+          transportPlaying={transportPlaying}
+          onTimeChange={setPreviewPositionSeconds}
+          onTransportChange={syncTransportPlayback}
+        />
 
         <Card className="border-white/10 bg-white/[0.04]">
           <CardHeader>

--- a/frontend/src/components/music/waveform-console.tsx
+++ b/frontend/src/components/music/waveform-console.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useRef, useState } from "react";
+import WaveSurfer from "wavesurfer.js";
+import { Pause, Play, TimerReset, Waves } from "lucide-react";
+
+import type { AudioAnalysis, SongSection, TrackSummary } from "@/lib/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+function formatClock(value: number) {
+  if (!Number.isFinite(value) || value < 0) {
+    return "0:00";
+  }
+
+  const totalSeconds = Math.floor(value);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function activeSection(sections: SongSection[], currentTime: number) {
+  return (
+    sections.find((section) => currentTime >= section.start_seconds && currentTime < section.end_seconds) ??
+    sections[0] ??
+    null
+  );
+}
+
+export function WaveformConsole({
+  track,
+  analysis,
+  currentTime,
+  transportPlaying,
+  onTimeChange,
+  onTransportChange,
+}: {
+  track: TrackSummary | null;
+  analysis: AudioAnalysis | null;
+  currentTime: number;
+  transportPlaying: boolean;
+  onTimeChange: (value: number) => void;
+  onTransportChange: (playing: boolean) => void;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const waveSurferRef = useRef<WaveSurfer | null>(null);
+  const [ready, setReady] = useState(false);
+  const [waveformError, setWaveformError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    const waveSurfer = WaveSurfer.create({
+      container: containerRef.current,
+      waveColor: "rgba(87, 169, 255, 0.3)",
+      progressColor: "rgba(162, 219, 255, 0.95)",
+      cursorColor: "#f8fafc",
+      cursorWidth: 2,
+      barWidth: 3,
+      barGap: 2,
+      barRadius: 999,
+      height: 220,
+      normalize: true,
+      dragToSeek: true,
+    });
+
+    waveSurferRef.current = waveSurfer;
+
+    waveSurfer.on("ready", () => {
+      setReady(true);
+      setWaveformError(null);
+      onTimeChange(0);
+    });
+
+    waveSurfer.on("timeupdate", (time) => {
+      onTimeChange(time);
+    });
+
+    waveSurfer.on("play", () => {
+      onTransportChange(true);
+    });
+
+    waveSurfer.on("pause", () => {
+      onTransportChange(false);
+    });
+
+    waveSurfer.on("finish", () => {
+      onTimeChange(0);
+      onTransportChange(false);
+    });
+
+    waveSurfer.on("error", (error) => {
+      setReady(false);
+      setWaveformError(error instanceof Error ? error.message : String(error));
+      onTransportChange(false);
+    });
+
+    return () => {
+      waveSurfer.destroy();
+      waveSurferRef.current = null;
+    };
+  }, [onTimeChange, onTransportChange]);
+
+  useEffect(() => {
+    const waveSurfer = waveSurferRef.current;
+    if (!waveSurfer) {
+      return;
+    }
+
+    setReady(false);
+    setWaveformError(null);
+    onTimeChange(0);
+
+    if (!track?.audio_url) {
+      waveSurfer.empty();
+      return;
+    }
+
+    void waveSurfer.load(track.audio_url);
+  }, [track?.audio_url, track?.track_id, onTimeChange, onTransportChange]);
+
+  const duration = analysis?.duration_seconds ?? track?.duration_seconds ?? 0;
+  const markerDuration = duration > 0 ? duration : 1;
+  const section = analysis ? activeSection(analysis.sections, currentTime) : null;
+
+  return (
+    <section className="rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(7,13,24,0.94),rgba(4,8,16,0.98))] p-6 shadow-[0_30px_80px_rgba(0,0,0,0.35)]">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Badge>Waveform Console</Badge>
+            <Badge variant="muted">{track?.source ?? "no source"}</Badge>
+            <Badge variant="accent">{ready ? "Preview Ready" : track ? "Loading Preview" : "Waiting on Track"}</Badge>
+          </div>
+          <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">
+            {track ? `${track.title} - ${track.artist}` : "Select a track to inspect the waveform"}
+          </h2>
+          <p className="mt-3 max-w-3xl text-sm text-slate-300 sm:text-base">
+            The waveform is now the main playback surface. Beat markers, downbeats, and section boundaries are derived
+            from the backend analysis payload so this view stays aligned with the choreography timeline.
+          </p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <ConsoleStat label="Time" value={formatClock(currentTime)} />
+          <ConsoleStat label="Duration" value={formatClock(duration)} />
+          <ConsoleStat label="Section" value={section?.label ?? "unknown"} />
+        </div>
+      </div>
+
+      <div className="mt-6 rounded-[28px] border border-white/10 bg-black/25 p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-3 py-2">
+              <Waves className="h-4 w-4 text-primary" />
+              {analysis ? `${analysis.waveform.bucket_count} waveform samples` : "Live audio preview"}
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-3 py-2">
+              {analysis ? `${analysis.beats.length} beats` : "No beat markers yet"}
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-3 py-2">
+              {analysis ? `${analysis.sections.length} sections` : "No sections yet"}
+            </span>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              variant="secondary"
+              disabled={!track?.audio_url || !ready}
+              onClick={() => {
+                waveSurferRef.current?.playPause();
+              }}
+            >
+              {transportPlaying ? <Pause className="mr-2 h-4 w-4" /> : <Play className="mr-2 h-4 w-4" />}
+              {transportPlaying ? "Pause Preview" : "Play Preview"}
+            </Button>
+            <Button
+              variant="ghost"
+              disabled={!track?.audio_url}
+              onClick={() => {
+                waveSurferRef.current?.setTime(0);
+                onTimeChange(0);
+              }}
+            >
+              <TimerReset className="mr-2 h-4 w-4" />
+              Restart
+            </Button>
+          </div>
+        </div>
+
+        <div className="relative mt-6 overflow-hidden rounded-[24px] border border-white/10 bg-[linear-gradient(180deg,rgba(10,18,31,0.92),rgba(6,11,21,0.98))] px-4 py-5">
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-16 bg-[linear-gradient(180deg,rgba(126,190,255,0.14),transparent)]" />
+          <div className="pointer-events-none absolute inset-y-6 left-4 right-4 z-20">
+            {analysis?.sections.map((item, index) => {
+              const left = `${(item.start_seconds / markerDuration) * 100}%`;
+              const width = `${Math.max(1.5, ((item.end_seconds - item.start_seconds) / markerDuration) * 100)}%`;
+              return (
+                <div
+                  key={`${item.label}-${index}`}
+                  className="absolute inset-y-0 rounded-2xl border border-primary/15 bg-primary/[0.06]"
+                  style={{ left, width }}
+                >
+                  <span className="absolute left-3 top-3 rounded-full bg-black/55 px-2 py-1 text-[10px] uppercase tracking-[0.22em] text-slate-200">
+                    {item.label}
+                  </span>
+                </div>
+              );
+            })}
+
+            {analysis?.beats.map((beat, index) => {
+              const isDownbeat = analysis.downbeats.some((downbeat) => Math.abs(downbeat - beat) < 0.03);
+              return (
+                <div
+                  key={`beat-${index}`}
+                  className={isDownbeat ? "absolute inset-y-0 w-px bg-white/60" : "absolute inset-y-4 w-px bg-primary/30"}
+                  style={{ left: `${(beat / markerDuration) * 100}%` }}
+                />
+              );
+            })}
+
+            <div
+              className="absolute inset-y-0 w-0.5 bg-white shadow-[0_0_20px_rgba(255,255,255,0.55)]"
+              style={{ left: `${Math.min(100, (currentTime / markerDuration) * 100)}%` }}
+            />
+          </div>
+
+          <div ref={containerRef} className="relative z-10 min-h-[220px]" />
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-400">
+          <div className="flex flex-wrap items-center gap-4">
+            <span>0:00</span>
+            <div className="h-px w-24 bg-white/10 sm:w-40" />
+            <span>{formatClock(duration)}</span>
+          </div>
+          {waveformError ? <span className="text-red-200">{waveformError}</span> : null}
+          {!track?.audio_url ? <span>Preview URL not available for this track.</span> : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ConsoleStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[22px] border border-white/10 bg-white/[0.04] px-4 py-3">
+      <p className="hud-label">{label}</p>
+      <p className="mt-2 text-lg font-semibold capitalize text-white">{value}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #14

## Summary
- add a wavesurfer.js waveform console as the primary playback surface
- move preview transport into the waveform console
- expose beat markers and section boundaries directly on the waveform view

## Verification
- npm run build