### PR TITLE
feat: add dual-arm adapter safety layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ Phase 1 now includes a real backend audio-analysis pipeline.
 - Remote Jamendo tracks are downloaded into the analysis cache before decoding
 - `/api/state` now reflects cached analysis data when available, instead of relying only on synthetic transport/spectrum placeholders
 
+## Dual-Arm Adapter Prep
+
+The backend now exposes a dry-run dual-arm execution surface for your SO-101 leader + follower setup.
+
+- `GET /api/arms` returns concrete adapter profiles for `leader` and `follower`
+- `POST /api/arms/execution-mode` switches between `mirror`, `unison`, `call_response`, and `asymmetric`
+- `POST /api/arms/{arm_id}/safety` updates per-arm dry-run/safety settings plus joint overrides for offsets, inversion, limits, and speed caps
+- `POST /api/arms/emergency-stop` disables torque in the adapter layer before any real motor writes are attempted
+- `POST /api/arms/neutral` moves the planning state back to the neutral scene
+
+This is still a planning and validation layer. It does not write to real hardware yet.
+
 Install or refresh backend dependencies after pulling:
 
 ```bash
@@ -147,4 +159,4 @@ Direct pushes to `main` should be avoided for feature work. The GitHub Actions w
 
 ## Next step
 
-The next engineering step is to finish the waveform-first frontend and the richer spectrogram/rhythm/structure tabs, then move into dual-arm LeRobot adapter and safety work.
+The next engineering step is the first real hardware execution pass that maps the dual-arm dry-run adapter to LeRobot motor commands with the existing safety envelope still enforced.

--- a/backend/app/arms.py
+++ b/backend/app/arms.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .models import (
+    ArmAdapterState,
+    ArmChannel,
+    ArmJointConfig,
+    ArmJointOverride,
+    ArmPreviewState,
+    ArmSafetyEnvelope,
+    ArmSafetyUpdate,
+    ArmType,
+    ChoreographyTimeline,
+    DualArmExecutionState,
+    DualArmState,
+    ExecutionMode,
+    MotionCue,
+    RobotConfig,
+    SceneName,
+)
+
+DEFAULT_JOINT_LAYOUT = [
+    (1, "shoulder_pan"),
+    (2, "shoulder_lift"),
+    (3, "elbow_flex"),
+    (4, "wrist_flex"),
+    (5, "wrist_roll"),
+    (6, "gripper"),
+]
+
+
+@dataclass
+class ArmRuntime:
+    arm_id: str
+    arm_type: ArmType
+    channel: ArmChannel
+    port: str | None
+    connected: bool
+    calibrated: bool
+    notes: str
+    safety: ArmSafetyEnvelope
+    joints: list[ArmJointConfig] = field(default_factory=list)
+
+
+class DualArmAdapter:
+    def __init__(self, config: RobotConfig) -> None:
+        self.execution_mode = ExecutionMode.MIRROR
+        self.neutral_pose_scene = SceneName.IDLE
+        self.required_dry_run = True
+        self.arms: dict[str, ArmRuntime] = {}
+
+        self._register_arm(
+            arm_id=config.leader_id or "leader_arm",
+            arm_type=ArmType.LEADER,
+            channel=ArmChannel.LEFT,
+            port=config.leader_port,
+        )
+        self._register_arm(
+            arm_id=config.follower_id,
+            arm_type=ArmType.FOLLOWER,
+            channel=ArmChannel.RIGHT,
+            port=config.follower_port,
+        )
+
+    def _register_arm(self, arm_id: str, arm_type: ArmType, channel: ArmChannel, port: str | None) -> None:
+        available = bool(port)
+        self.arms[arm_id] = ArmRuntime(
+            arm_id=arm_id,
+            arm_type=arm_type,
+            channel=channel,
+            port=port,
+            connected=available,
+            calibrated=available,
+            notes=self._default_note(arm_type),
+            safety=self._default_safety(arm_type),
+            joints=self._default_joints(arm_type),
+        )
+
+    def _default_note(self, arm_type: ArmType) -> str:
+        if arm_type == ArmType.LEADER:
+            return "Leader profile starts in conservative dry-run mode and should be recalibrated before motor writes."
+        return "Follower profile is staged for choreography playback but remains dry-run only."
+
+    def _default_safety(self, arm_type: ArmType) -> ArmSafetyEnvelope:
+        if arm_type == ArmType.LEADER:
+            return ArmSafetyEnvelope(dry_run=True, amplitude_scale=0.82, speed_scale=0.85, max_step_degrees=10.0)
+        return ArmSafetyEnvelope(dry_run=True, amplitude_scale=1.0, speed_scale=1.0, max_step_degrees=12.0)
+
+    def _default_joints(self, arm_type: ArmType) -> list[ArmJointConfig]:
+        joints: list[ArmJointConfig] = []
+        for servo_id, name in DEFAULT_JOINT_LAYOUT:
+            inverted = arm_type == ArmType.LEADER and name in {"wrist_roll", "gripper"}
+            offset = 4.0 if arm_type == ArmType.LEADER and name == "shoulder_pan" else 0.0
+            max_speed = 0.85 if arm_type == ArmType.LEADER and name in {"wrist_roll", "gripper"} else 1.0
+            joints.append(
+                ArmJointConfig(
+                    joint_name=name,
+                    servo_id=servo_id,
+                    inverted=inverted,
+                    offset_degrees=offset,
+                    min_angle=-115.0 if arm_type == ArmType.LEADER else -120.0,
+                    max_angle=115.0 if arm_type == ArmType.LEADER else 120.0,
+                    max_speed=max_speed,
+                )
+            )
+        return joints
+
+    def any_connected(self) -> bool:
+        return any(arm.connected for arm in self.arms.values())
+
+    def emergency_stop_active(self) -> bool:
+        return any(arm.safety.emergency_stop for arm in self.arms.values())
+
+    def set_execution_mode(self, mode: ExecutionMode) -> None:
+        self.execution_mode = mode
+
+    def set_connection(self, arm_id: str, connected: bool) -> None:
+        arm = self._arm(arm_id)
+        if connected and not arm.port:
+            raise ValueError(f"Arm '{arm_id}' has no configured port")
+        arm.connected = connected
+        if not connected:
+            arm.safety.torque_enabled = False
+
+    def update_safety(self, arm_id: str, payload: ArmSafetyUpdate) -> None:
+        arm = self._arm(arm_id)
+
+        for field_name in (
+            "dry_run",
+            "emergency_stop",
+            "neutral_on_stop",
+            "torque_enabled",
+            "amplitude_scale",
+            "speed_scale",
+            "max_step_degrees",
+        ):
+            value = getattr(payload, field_name)
+            if value is not None:
+                setattr(arm.safety, field_name, value)
+
+        for override in payload.joint_overrides:
+            self._apply_joint_override(arm, override)
+
+        if arm.safety.emergency_stop:
+            arm.safety.torque_enabled = False
+
+    def emergency_stop(self) -> None:
+        for arm in self.arms.values():
+            arm.safety.emergency_stop = True
+            arm.safety.torque_enabled = False
+
+    def neutralize(self) -> None:
+        self.neutral_pose_scene = SceneName.IDLE
+
+    def snapshot(self, choreography: ChoreographyTimeline | None, position_seconds: float) -> DualArmState:
+        choreography_ready = choreography is not None
+        arms: list[ArmAdapterState] = []
+        for arm in self.arms.values():
+            channel_cues = self._channel_cues(choreography, arm.channel)
+            arms.append(
+                ArmAdapterState(
+                    arm_id=arm.arm_id,
+                    arm_type=arm.arm_type,
+                    channel=arm.channel,
+                    port=arm.port,
+                    available=bool(arm.port),
+                    connected=arm.connected,
+                    calibrated=arm.calibrated,
+                    safety=arm.safety.model_copy(deep=True),
+                    joints=[joint.model_copy(deep=True) for joint in arm.joints],
+                    preview=self._preview(channel_cues, arm.channel, position_seconds),
+                    notes=arm.notes,
+                )
+            )
+
+        return DualArmState(
+            arms=arms,
+            execution=DualArmExecutionState(
+                mode=self.execution_mode,
+                choreography_ready=choreography_ready,
+                dry_run_required=self.required_dry_run,
+                emergency_stop_active=self.emergency_stop_active(),
+                neutral_pose_scene=self.neutral_pose_scene,
+            ),
+        )
+
+    def _channel_cues(self, choreography: ChoreographyTimeline | None, channel: ArmChannel) -> list[MotionCue]:
+        if choreography is None:
+            return []
+        if channel == ArmChannel.LEFT:
+            return choreography.arm_left_cues
+        return choreography.arm_right_cues
+
+    def _preview(self, cues: list[MotionCue], channel: ArmChannel, position_seconds: float) -> ArmPreviewState:
+        current = self._current_cue(cues, position_seconds)
+        upcoming = next((cue for cue in cues if cue.time >= position_seconds), None)
+        return ArmPreviewState(
+            channel=channel,
+            current_pose_family=current.pose_family if current else None,
+            current_cue_kind=current.kind if current else None,
+            symmetry_role=current.symmetry_role if current else None,
+            next_cue_time=round(upcoming.time, 3) if upcoming else None,
+            note=current.notes if current else "Waiting on choreography cues",
+        )
+
+    def _current_cue(self, cues: list[MotionCue], position_seconds: float) -> MotionCue | None:
+        active: MotionCue | None = None
+        for cue in cues:
+            if cue.time <= position_seconds:
+                active = cue
+            else:
+                break
+        return active
+
+    def _apply_joint_override(self, arm: ArmRuntime, override: ArmJointOverride) -> None:
+        joint = next((item for item in arm.joints if item.joint_name == override.joint_name), None)
+        if joint is None:
+            raise ValueError(f"Unknown joint '{override.joint_name}' for arm '{arm.arm_id}'")
+
+        if override.inverted is not None:
+            joint.inverted = override.inverted
+        if override.offset_degrees is not None:
+            joint.offset_degrees = override.offset_degrees
+        if override.min_angle is not None:
+            joint.min_angle = override.min_angle
+        if override.max_angle is not None:
+            joint.max_angle = override.max_angle
+        if override.max_speed is not None:
+            joint.max_speed = override.max_speed
+
+    def _arm(self, arm_id: str) -> ArmRuntime:
+        arm = self.arms.get(arm_id)
+        if arm is None:
+            raise ValueError(f"Unknown arm id: {arm_id}")
+        return arm

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,8 +11,12 @@ from .models import (
     AnalysisStartResponse,
     AnalysisStatus,
     AnalysisStatusResponse,
+    ArmConnectionUpdate,
+    ArmSafetyUpdate,
     AudioAnalysis,
     ChoreographyTimeline,
+    DualArmState,
+    ExecutionModeUpdate,
     ModeUpdate,
     PulseUpdate,
     RobotConfig,
@@ -94,6 +98,42 @@ def update_servo(servo_id: int, payload: ServoUpdate) -> RobotState:
         return store.update_servo(servo_id, payload)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.get("/api/arms", response_model=DualArmState)
+def get_arms() -> DualArmState:
+    return store.arms_snapshot()
+
+
+@app.post("/api/arms/execution-mode", response_model=DualArmState)
+def update_execution_mode(payload: ExecutionModeUpdate) -> DualArmState:
+    return store.set_execution_mode(payload)
+
+
+@app.post("/api/arms/{arm_id}/connect", response_model=DualArmState)
+def update_arm_connection(arm_id: str, payload: ArmConnectionUpdate) -> DualArmState:
+    try:
+        return store.set_arm_connection(arm_id, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.post("/api/arms/{arm_id}/safety", response_model=DualArmState)
+def update_arm_safety(arm_id: str, payload: ArmSafetyUpdate) -> DualArmState:
+    try:
+        return store.update_arm_safety(arm_id, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@app.post("/api/arms/emergency-stop", response_model=DualArmState)
+def emergency_stop() -> DualArmState:
+    return store.emergency_stop()
+
+
+@app.post("/api/arms/neutral", response_model=DualArmState)
+def move_arms_to_neutral() -> DualArmState:
+    return store.move_to_neutral()
 
 
 @app.get("/api/tracks/search", response_model=TrackSearchResponse)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -66,6 +66,23 @@ class SymmetryRole(str, Enum):
     CONTRAST = "contrast"
 
 
+class ArmType(str, Enum):
+    FOLLOWER = "follower"
+    LEADER = "leader"
+
+
+class ArmChannel(str, Enum):
+    LEFT = "left"
+    RIGHT = "right"
+
+
+class ExecutionMode(str, Enum):
+    MIRROR = "mirror"
+    UNISON = "unison"
+    CALL_RESPONSE = "call_response"
+    ASYMMETRIC = "asymmetric"
+
+
 class RobotConfig(BaseModel):
     assembly: str = "Follower"
     follower_id: str = "follower_arm"
@@ -114,12 +131,78 @@ class ServoState(BaseModel):
     motion_phase: str = "steady"
 
 
+class ArmJointConfig(BaseModel):
+    joint_name: str
+    servo_id: int
+    inverted: bool = False
+    offset_degrees: float = Field(default=0.0, ge=-180.0, le=180.0)
+    min_angle: float = Field(default=-120.0, ge=-180.0, le=180.0)
+    max_angle: float = Field(default=120.0, ge=-180.0, le=180.0)
+    max_speed: float = Field(default=1.0, ge=0.1, le=2.0)
+
+
+class ArmPreviewState(BaseModel):
+    channel: ArmChannel
+    current_pose_family: PoseFamily | None = None
+    current_cue_kind: MotionCueKind | None = None
+    symmetry_role: SymmetryRole | None = None
+    next_cue_time: float | None = Field(default=None, ge=0.0)
+    note: str | None = None
+
+
+class ArmSafetyEnvelope(BaseModel):
+    dry_run: bool = True
+    emergency_stop: bool = False
+    neutral_on_stop: bool = True
+    torque_enabled: bool = True
+    amplitude_scale: float = Field(default=1.0, ge=0.1, le=2.0)
+    speed_scale: float = Field(default=1.0, ge=0.1, le=2.0)
+    max_step_degrees: float = Field(default=12.0, ge=1.0, le=45.0)
+
+
+class ArmAdapterState(BaseModel):
+    arm_id: str
+    arm_type: ArmType
+    channel: ArmChannel
+    port: str | None = None
+    available: bool
+    connected: bool
+    calibrated: bool
+    safety: ArmSafetyEnvelope
+    joints: list[ArmJointConfig]
+    preview: ArmPreviewState
+    notes: str | None = None
+
+
+class DualArmExecutionState(BaseModel):
+    mode: ExecutionMode
+    choreography_ready: bool = False
+    dry_run_required: bool = True
+    emergency_stop_active: bool = False
+    neutral_pose_scene: SceneName = SceneName.IDLE
+    supported_modes: list[ExecutionMode] = Field(
+        default_factory=lambda: [
+            ExecutionMode.MIRROR,
+            ExecutionMode.UNISON,
+            ExecutionMode.CALL_RESPONSE,
+            ExecutionMode.ASYMMETRIC,
+        ]
+    )
+
+
+class DualArmState(BaseModel):
+    arms: list[ArmAdapterState]
+    execution: DualArmExecutionState
+
+
 class RobotState(BaseModel):
     connected: bool
     status: str
     mode: DanceMode
     follower_id: str
     follower_port: str
+    leader_id: str | None = None
+    leader_port: str | None = None
     safety_step_ticks: int
     latency_ms: int
     sync_quality: int = Field(ge=0, le=100)
@@ -127,6 +210,7 @@ class RobotState(BaseModel):
     transport: TransportState
     spectrum: list[int]
     servos: list[ServoState]
+    dual_arm: DualArmState
 
 
 class ModeUpdate(BaseModel):
@@ -152,6 +236,34 @@ class PulseUpdate(BaseModel):
 class ServoUpdate(BaseModel):
     target_angle: float | None = Field(default=None, ge=-140.0, le=140.0)
     torque_enabled: bool | None = None
+
+
+class ArmConnectionUpdate(BaseModel):
+    connected: bool = True
+
+
+class ArmJointOverride(BaseModel):
+    joint_name: str
+    inverted: bool | None = None
+    offset_degrees: float | None = Field(default=None, ge=-180.0, le=180.0)
+    min_angle: float | None = Field(default=None, ge=-180.0, le=180.0)
+    max_angle: float | None = Field(default=None, ge=-180.0, le=180.0)
+    max_speed: float | None = Field(default=None, ge=0.1, le=2.0)
+
+
+class ArmSafetyUpdate(BaseModel):
+    dry_run: bool | None = None
+    emergency_stop: bool | None = None
+    neutral_on_stop: bool | None = None
+    torque_enabled: bool | None = None
+    amplitude_scale: float | None = Field(default=None, ge=0.1, le=2.0)
+    speed_scale: float | None = Field(default=None, ge=0.1, le=2.0)
+    max_step_degrees: float | None = Field(default=None, ge=1.0, le=45.0)
+    joint_overrides: list[ArmJointOverride] = Field(default_factory=list)
+
+
+class ExecutionModeUpdate(BaseModel):
+    mode: ExecutionMode
 
 
 class TrackSearchResponse(BaseModel):

--- a/backend/app/state.py
+++ b/backend/app/state.py
@@ -7,13 +7,19 @@ from datetime import UTC, datetime
 from pathlib import Path
 from time import monotonic
 
+from .arms import DEFAULT_JOINT_LAYOUT, DualArmAdapter
 from .models import (
     AnalysisStartResponse,
     AnalysisStatus,
     AnalysisStatusResponse,
+    ArmConnectionUpdate,
+    ArmSafetyUpdate,
     AudioAnalysis,
     ChoreographyTimeline,
     DanceMode,
+    DualArmState,
+    ExecutionMode,
+    ExecutionModeUpdate,
     MotionCue,
     PulseUpdate,
     RobotConfig,
@@ -33,14 +39,7 @@ from .models import (
 ROOT_DIR = Path(__file__).resolve().parents[2]
 SETUP_PATH = ROOT_DIR / ".data" / "setup.json"
 
-SERVO_LAYOUT = [
-    (1, "shoulder_pan"),
-    (2, "shoulder_lift"),
-    (3, "elbow_flex"),
-    (4, "wrist_flex"),
-    (5, "wrist_roll"),
-    (6, "gripper"),
-]
+SERVO_LAYOUT = DEFAULT_JOINT_LAYOUT
 
 SCENES: dict[SceneName, dict[str, float]] = {
     SceneName.IDLE: {
@@ -90,18 +89,10 @@ class ServoRuntime:
     motion_phase: str = "steady"
 
 
-class LeRobotBridge:
-    def __init__(self, config: RobotConfig) -> None:
-        self.config = config
-
-    def connection_ok(self) -> bool:
-        return bool(self.config.follower_port)
-
-
 class RobotStateStore:
-    def __init__(self) -> None:
-        self.config = self._load_config()
-        self.bridge = LeRobotBridge(self.config)
+    def __init__(self, config: RobotConfig | None = None) -> None:
+        self.config = config or self._load_config()
+        self.arm_adapter = DualArmAdapter(self.config)
         self.mode = DanceMode.IDLE
         self.transport = TransportState()
         self.status = "ready"
@@ -119,6 +110,7 @@ class RobotStateStore:
             for servo_id, name in SERVO_LAYOUT
         ]
         self._set_scene_targets(SceneName.IDLE)
+        self._sync_follower_torque_state()
 
     def _load_config(self) -> RobotConfig:
         if not SETUP_PATH.exists():
@@ -131,6 +123,10 @@ class RobotStateStore:
         now = monotonic()
         delta = max(now - self.last_tick, 0.05)
         self.last_tick = now
+
+        if self.arm_adapter.emergency_stop_active():
+            self.transport.playing = False
+            self.mode = DanceMode.IDLE
 
         if self.transport.playing:
             self.transport.position_seconds += delta
@@ -221,14 +217,17 @@ class RobotStateStore:
 
     def snapshot(self) -> RobotState:
         self._tick()
-        connected = self.bridge.connection_ok()
+        connected = self.arm_adapter.any_connected()
         spectrum = self._build_spectrum()
+        dual_arm = self.arm_adapter.snapshot(self.current_choreography(), self.transport.position_seconds)
         return RobotState(
             connected=connected,
             status=self.status,
             mode=self.mode,
             follower_id=self.config.follower_id,
             follower_port=self.config.follower_port,
+            leader_id=self.config.leader_id,
+            leader_port=self.config.leader_port,
             safety_step_ticks=self.config.safety_step_ticks,
             latency_ms=self.latency_ms,
             sync_quality=self.sync_quality,
@@ -248,6 +247,7 @@ class RobotStateStore:
                 )
                 for servo in self.servos
             ],
+            dual_arm=dual_arm,
         )
 
     def _build_spectrum(self) -> list[int]:
@@ -276,6 +276,8 @@ class RobotStateStore:
         return bars
 
     def set_mode(self, mode: DanceMode) -> RobotState:
+        if self.arm_adapter.emergency_stop_active() and mode != DanceMode.IDLE:
+            mode = DanceMode.IDLE
         self.mode = mode
         if mode == DanceMode.IDLE:
             self.apply_scene(SceneName.IDLE)
@@ -286,8 +288,8 @@ class RobotStateStore:
         self.transport.track_name = payload.track_name
         self.transport.bpm = payload.bpm
         self.transport.energy = payload.energy
-        self.transport.playing = payload.playing
-        if payload.playing and self.mode == DanceMode.IDLE:
+        self.transport.playing = False if self.arm_adapter.emergency_stop_active() else payload.playing
+        if self.transport.playing and self.mode == DanceMode.IDLE:
             self.mode = DanceMode.AUTONOMOUS
         return self.snapshot()
 
@@ -298,13 +300,15 @@ class RobotStateStore:
     def pulse(self, payload: PulseUpdate) -> RobotState:
         self.transport.bpm = payload.bpm
         self.transport.energy = payload.energy
-        self.transport.playing = True
-        self.mode = DanceMode.PULSE
+        self.transport.playing = not self.arm_adapter.emergency_stop_active()
+        self.mode = DanceMode.IDLE if self.arm_adapter.emergency_stop_active() else DanceMode.PULSE
         if self.scene == SceneName.IDLE:
             self.scene = SceneName.BLOOM
         return self.snapshot()
 
     def update_servo(self, servo_id: int, payload: ServoUpdate) -> RobotState:
+        if self.arm_adapter.emergency_stop_active():
+            raise ValueError("Emergency stop is active")
         servo = next((item for item in self.servos if item.id == servo_id), None)
         if servo is None:
             raise ValueError(f"Unknown servo id: {servo_id}")
@@ -314,6 +318,7 @@ class RobotStateStore:
             servo.target_angle = payload.target_angle
         if payload.torque_enabled is not None:
             servo.torque_enabled = payload.torque_enabled
+            self._sync_follower_torque_state()
 
         return self.snapshot()
 
@@ -377,6 +382,43 @@ class RobotStateStore:
         if track is None:
             return None
         return self.choreography_results.get(self._track_key(track.source, track.track_id))
+
+    def arms_snapshot(self) -> DualArmState:
+        self._tick()
+        return self.arm_adapter.snapshot(self.current_choreography(), self.transport.position_seconds)
+
+    def set_execution_mode(self, payload: ExecutionModeUpdate) -> DualArmState:
+        self.arm_adapter.set_execution_mode(payload.mode)
+        return self.arms_snapshot()
+
+    def set_arm_connection(self, arm_id: str, payload: ArmConnectionUpdate) -> DualArmState:
+        self.arm_adapter.set_connection(arm_id, payload.connected)
+        self._sync_follower_torque_state()
+        return self.arms_snapshot()
+
+    def update_arm_safety(self, arm_id: str, payload: ArmSafetyUpdate) -> DualArmState:
+        self.arm_adapter.update_safety(arm_id, payload)
+        if self.arm_adapter.emergency_stop_active():
+            self.transport.playing = False
+            self.mode = DanceMode.IDLE
+            self._set_scene_targets(SceneName.IDLE)
+        self._sync_follower_torque_state()
+        return self.arms_snapshot()
+
+    def emergency_stop(self) -> DualArmState:
+        self.arm_adapter.emergency_stop()
+        self.transport.playing = False
+        self.mode = DanceMode.IDLE
+        self._set_scene_targets(SceneName.IDLE)
+        self._sync_follower_torque_state()
+        return self.arms_snapshot()
+
+    def move_to_neutral(self) -> DualArmState:
+        self.arm_adapter.neutralize()
+        self.transport.playing = False
+        self.mode = DanceMode.IDLE
+        self._set_scene_targets(SceneName.IDLE)
+        return self.arms_snapshot()
 
     def queue_analysis(self, payload: TrackReference) -> AnalysisStartResponse:
         self.analysis_results.pop(self._track_key(payload.source, payload.track_id), None)
@@ -509,6 +551,14 @@ class RobotStateStore:
         end = min(len(values), index + radius + 1)
         window = values[start:end] or [values[max(0, min(len(values) - 1, index))]]
         return sum(window) / len(window)
+
+    def _sync_follower_torque_state(self) -> None:
+        follower = self.arm_adapter.arms.get(self.config.follower_id)
+        if follower is None:
+            return
+        torque_enabled = follower.safety.torque_enabled and not follower.safety.emergency_stop
+        for servo in self.servos:
+            servo.torque_enabled = torque_enabled
 
     def _servo_driver(
         self,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -13,6 +13,7 @@ from fastapi.testclient import TestClient
 from backend.app import main as main_module
 from backend.app.analysis import AudioAnalysisCache, AudioAnalysisService
 from backend.app.music import JamendoTrackProvider, LocalTrackLibrary
+from backend.app.models import RobotConfig
 from backend.app.state import RobotStateStore
 
 
@@ -27,7 +28,15 @@ class ApiSmokeTest(unittest.TestCase):
         self.original_local_library = main_module.local_library
         self.original_analysis_service = main_module.analysis_service
 
-        main_module.store = RobotStateStore()
+        main_module.store = RobotStateStore(
+            config=RobotConfig(
+                follower_id="test_follower",
+                follower_port="/dev/mock-follower",
+                leader_id="test_leader",
+                leader_port="/dev/mock-leader",
+                safety_step_ticks=120,
+            )
+        )
         main_module.local_library = LocalTrackLibrary(
             uploads_dir=uploads_root,
             media_base_url="/media/uploads",
@@ -82,6 +91,8 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertAlmostEqual(state_payload["transport"]["energy"], payload["energy"]["rms"][0], places=3)
         expected_spectrum = self._expected_spectrum_prefix(payload)
         self.assertEqual(state_payload["spectrum"][:3], expected_spectrum)
+        self.assertEqual(len(state_payload["dual_arm"]["arms"]), 2)
+        self.assertEqual(state_payload["dual_arm"]["execution"]["mode"], "mirror")
 
         choreography = self.client.get(f"/api/choreography/{track['source']}/{track['track_id']}")
         self.assertEqual(choreography.status_code, 200)
@@ -97,6 +108,58 @@ class ApiSmokeTest(unittest.TestCase):
             any(cue["kind"] == "accent" for cue in choreography_payload["global_cues"])
             or any(cue["kind"] == "hold" for cue in choreography_payload["global_cues"])
         )
+
+        arms = self.client.get("/api/arms")
+        self.assertEqual(arms.status_code, 200)
+        arms_payload = arms.json()
+        self.assertEqual(len(arms_payload["arms"]), 2)
+        self.assertTrue(arms_payload["execution"]["dry_run_required"])
+        self.assertEqual(
+            {arm["arm_type"] for arm in arms_payload["arms"]},
+            {"leader", "follower"},
+        )
+
+        mode_update = self.client.post("/api/arms/execution-mode", json={"mode": "call_response"})
+        self.assertEqual(mode_update.status_code, 200)
+        self.assertEqual(mode_update.json()["execution"]["mode"], "call_response")
+
+        safety_update = self.client.post(
+            "/api/arms/test_leader/safety",
+            json={
+                "amplitude_scale": 0.74,
+                "speed_scale": 0.8,
+                "joint_overrides": [
+                    {
+                        "joint_name": "wrist_roll",
+                        "inverted": False,
+                        "offset_degrees": 7.5,
+                        "max_speed": 0.7,
+                    }
+                ],
+            },
+        )
+        self.assertEqual(safety_update.status_code, 200)
+        leader = next(arm for arm in safety_update.json()["arms"] if arm["arm_id"] == "test_leader")
+        self.assertAlmostEqual(leader["safety"]["amplitude_scale"], 0.74, places=2)
+        wrist_roll = next(joint for joint in leader["joints"] if joint["joint_name"] == "wrist_roll")
+        self.assertFalse(wrist_roll["inverted"])
+        self.assertAlmostEqual(wrist_roll["offset_degrees"], 7.5, places=2)
+        self.assertAlmostEqual(wrist_roll["max_speed"], 0.7, places=2)
+
+        emergency_stop = self.client.post("/api/arms/emergency-stop")
+        self.assertEqual(emergency_stop.status_code, 200)
+        estop_payload = emergency_stop.json()
+        self.assertTrue(estop_payload["execution"]["emergency_stop_active"])
+        self.assertTrue(all(not arm["safety"]["torque_enabled"] for arm in estop_payload["arms"]))
+
+        state_after_stop = self.client.get("/api/state")
+        self.assertEqual(state_after_stop.status_code, 200)
+        self.assertFalse(state_after_stop.json()["transport"]["playing"])
+        self.assertTrue(all(not servo["torque_enabled"] for servo in state_after_stop.json()["servos"]))
+
+        neutral = self.client.post("/api/arms/neutral")
+        self.assertEqual(neutral.status_code, 200)
+        self.assertEqual(neutral.json()["execution"]["neutral_pose_scene"], "idle")
 
         cache_files = list((Path(self.tempdir.name) / "analysis-cache" / "json" / "local").glob("*.json"))
         self.assertTrue(cache_files)

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -77,6 +77,55 @@ These contracts started ahead of the implementation. The real backend analysis p
 - `404`: track is unknown or choreography does not exist yet
 - `409`: choreography is blocked on analysis
 
+## Dual-Arm Adapter Endpoints
+
+### `GET /api/arms`
+- Response: `DualArmState`
+
+### `POST /api/arms/execution-mode`
+- Body:
+```json
+{
+  "mode": "mirror"
+}
+```
+- Response: `DualArmState`
+
+### `POST /api/arms/{arm_id}/connect`
+- Body:
+```json
+{
+  "connected": true
+}
+```
+- Response: `DualArmState`
+
+### `POST /api/arms/{arm_id}/safety`
+- Body:
+```json
+{
+  "dry_run": true,
+  "amplitude_scale": 0.82,
+  "speed_scale": 0.85,
+  "max_step_degrees": 10,
+  "joint_overrides": [
+    {
+      "joint_name": "wrist_roll",
+      "inverted": false,
+      "offset_degrees": 7.5,
+      "max_speed": 0.7
+    }
+  ]
+}
+```
+- Response: `DualArmState`
+
+### `POST /api/arms/emergency-stop`
+- Response: `DualArmState`
+
+### `POST /api/arms/neutral`
+- Response: `DualArmState`
+
 ## Canonical Models
 
 ### `TrackSummary`
@@ -126,10 +175,28 @@ These contracts started ahead of the implementation. The real backend analysis p
 - `symmetry_role`
 - `notes`
 
+### `DualArmState`
+- `arms`
+- `execution`
+
+### `ArmAdapterState`
+- `arm_id`
+- `arm_type`
+- `channel`
+- `port`
+- `available`
+- `connected`
+- `calibrated`
+- `safety`
+- `joints`
+- `preview`
+- `notes`
+
 ## Compatibility Notes
 - `motion_profile` remains present for compatibility with the existing UI.
 - `analysis_status` is now part of `TrackSummary`.
 - Local uploads should be selectable through the same UI card flow as Jamendo tracks.
 - `POST /api/analysis/start` now performs the analysis synchronously for Phase 1 while still updating the stored status lifecycle (`queued` -> `processing` -> `ready|error`).
 - Analysis results are cached on disk under `.data/analysis-cache/` keyed by `source + track_id`.
-- `AudioAnalysis.choreography` currently contains a basic beat/section-derived cue timeline. Richer dual-arm choreography generation is tracked separately in `#13`.
+- `AudioAnalysis.choreography` exposes the timeline consumed by the dual-arm adapter preview.
+- `GET /api/state` now returns a `dual_arm` block in addition to the legacy single-arm servo view so the frontend can evolve without breaking existing responses.

--- a/docs/IMPLEMENTATION_TRACKER.md
+++ b/docs/IMPLEMENTATION_TRACKER.md
@@ -16,15 +16,15 @@ The delivery sequence is:
 - `#11` Add local audio upload and analyzable track source pipeline [done]
 - `#12` Implement backend audio analysis pipeline with librosa and caching [done]
 - `#13` Generate dual-arm choreography timelines from analysis data [done]
-- `#14` Build waveform-first music console on the frontend
-- `#15` Add spectrogram, rhythm, structure, and track-info analysis tabs
-- `#16` Replace synthetic backend motion data with real audio analysis state
-- `#17` Prepare dual-arm LeRobot adapter and safety envelope
+- `#14` Build waveform-first music console on the frontend [done]
+- `#15` Add spectrogram, rhythm, structure, and track-info analysis tabs [done]
+- `#16` Replace synthetic backend motion data with real audio analysis state [done]
+- `#17` Prepare dual-arm LeRobot adapter and safety envelope [done]
 - `#19` Add GitHub Actions CI for backend, frontend, and smoke validation
 - `#20` Dockerize frontend and backend with docker compose startup
 
 ## Current Status
-- Current PR target: `#16`
+- Current PR target: `#17`
 - Current backend state:
   - Search and track selection exist
   - Local upload and persistent local track metadata are available
@@ -32,11 +32,13 @@ The delivery sequence is:
   - Analysis results are cached on disk under `.data/analysis-cache/`
   - Dual-arm choreography output is section-aware and exposes left/right arm cue channels
   - `/api/state` now derives transport BPM, energy, spectrum bars, and autonomous servo modulation from cached analysis when it exists
+  - Dual-arm adapter profiles now exist for leader + follower with dry-run defaults, safety envelopes, execution modes, and emergency-stop/neutral planning endpoints
 - Current frontend state:
   - Home page is music-first
   - Search/select flow exists
   - Minimal local upload/select flow exists without redesigning the page
   - Analysis tabs are wired to the real backend analysis payload
+  - Waveform-first playback and analysis workstation views are in place
 
 ## Workflow Rule
 - Each ticket must ship from a feature branch through a pull request.

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -6,6 +6,9 @@ export type SectionLabel = "intro" | "verse" | "chorus" | "bridge" | "break" | "
 export type MotionCueKind = "beat" | "downbeat" | "accent" | "section_change" | "hold";
 export type PoseFamily = "groove" | "sweep" | "punch" | "float";
 export type SymmetryRole = "lead" | "follow" | "mirror" | "unison" | "contrast";
+export type ArmType = "follower" | "leader";
+export type ArmChannel = "left" | "right";
+export type ExecutionMode = "mirror" | "unison" | "call_response" | "asymmetric";
 
 export interface RobotConfig {
   assembly: string;
@@ -151,12 +154,71 @@ export interface ServoState {
   motion_phase: "steady" | "ramping" | "accent";
 }
 
+export interface ArmJointConfig {
+  joint_name: string;
+  servo_id: number;
+  inverted: boolean;
+  offset_degrees: number;
+  min_angle: number;
+  max_angle: number;
+  max_speed: number;
+}
+
+export interface ArmPreviewState {
+  channel: ArmChannel;
+  current_pose_family?: PoseFamily | null;
+  current_cue_kind?: MotionCueKind | null;
+  symmetry_role?: SymmetryRole | null;
+  next_cue_time?: number | null;
+  note?: string | null;
+}
+
+export interface ArmSafetyEnvelope {
+  dry_run: boolean;
+  emergency_stop: boolean;
+  neutral_on_stop: boolean;
+  torque_enabled: boolean;
+  amplitude_scale: number;
+  speed_scale: number;
+  max_step_degrees: number;
+}
+
+export interface ArmAdapterState {
+  arm_id: string;
+  arm_type: ArmType;
+  channel: ArmChannel;
+  port?: string | null;
+  available: boolean;
+  connected: boolean;
+  calibrated: boolean;
+  safety: ArmSafetyEnvelope;
+  joints: ArmJointConfig[];
+  preview: ArmPreviewState;
+  notes?: string | null;
+}
+
+export interface DualArmExecutionState {
+  mode: ExecutionMode;
+  choreography_ready: boolean;
+  dry_run_required: boolean;
+  emergency_stop_active: boolean;
+  neutral_pose_scene: SceneName;
+  supported_modes: ExecutionMode[];
+}
+
+export interface DualArmState {
+  arms: ArmAdapterState[];
+  execution: DualArmExecutionState;
+}
+
 export interface RobotState {
   connected: boolean;
   status: string;
   mode: DanceMode;
   follower_id: string;
   follower_port: string;
+  leader_id?: string | null;
+  leader_port?: string | null;
   safety_step_ticks: number;
   latency_ms: number;
   sync_quality: number;
@@ -164,4 +226,5 @@ export interface RobotState {
   transport: TransportState;
   spectrum: number[];
   servos: ServoState[];
+  dual_arm: DualArmState;
 }


### PR DESCRIPTION
Refs #17

## Summary
- add dual-arm adapter profiles for leader and follower with dry-run safety defaults
- expose execution-mode, connection, safety, emergency-stop, and neutral APIs
- carry the dual-arm execution/safety state through backend models, docs, and smoke coverage

## Verification
- python3 -m compileall backend/app
- /Users/juliennigou/LeJRobot/backend/.venv/bin/python -m unittest discover -s backend/tests -v
- npm run build