### PR TITLE
feat: verify live arm readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,13 @@ Phase 1 now includes a real backend audio-analysis pipeline.
 The backend now exposes a dry-run dual-arm execution surface for your SO-101 leader + follower setup.
 
 - `GET /api/arms` returns concrete adapter profiles for `leader` and `follower`
+- `POST /api/arms/verify` checks dependency availability, serial-port reachability, and calibration coverage for both arms
 - `POST /api/arms/execution-mode` switches between `mirror`, `unison`, `call_response`, and `asymmetric`
 - `POST /api/arms/{arm_id}/safety` updates per-arm dry-run/safety settings plus joint overrides for offsets, inversion, limits, and speed caps
 - `POST /api/arms/emergency-stop` disables torque in the adapter layer before any real motor writes are attempted
 - `POST /api/arms/neutral` moves the planning state back to the neutral scene
 
-This is still a planning and validation layer. It does not write to real hardware yet.
+This is still a planning and validation layer. It does not write choreography to real hardware yet, but it now reports whether each arm is actually ready for the live execution phase.
 
 Install or refresh backend dependencies after pulling:
 

--- a/backend/app/arms.py
+++ b/backend/app/arms.py
@@ -1,6 +1,20 @@
 from __future__ import annotations
 
+import importlib.util
+import json
+import os
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+try:
+    import serial
+    from serial import SerialException
+except ImportError:  # pragma: no cover - handled in verification status
+    serial = None
+
+    class SerialException(Exception):
+        pass
 
 from .models import (
     ArmAdapterState,
@@ -11,6 +25,8 @@ from .models import (
     ArmSafetyEnvelope,
     ArmSafetyUpdate,
     ArmType,
+    ArmVerificationState,
+    ArmVerificationStatus,
     ChoreographyTimeline,
     DualArmExecutionState,
     DualArmState,
@@ -29,6 +45,9 @@ DEFAULT_JOINT_LAYOUT = [
     (6, "gripper"),
 ]
 
+ROOT_DIR = Path(__file__).resolve().parents[2]
+DEFAULT_EXPECTED_JOINT_COUNT = len(DEFAULT_JOINT_LAYOUT)
+
 
 @dataclass
 class ArmRuntime:
@@ -40,15 +59,191 @@ class ArmRuntime:
     calibrated: bool
     notes: str
     safety: ArmSafetyEnvelope
+    verification: ArmVerificationState
     joints: list[ArmJointConfig] = field(default_factory=list)
 
 
+class LeRobotArmVerifier:
+    def verify(self, arm: ArmRuntime) -> ArmVerificationState:
+        dependency_available = importlib.util.find_spec("lerobot") is not None
+        port_present = bool(arm.port and Path(arm.port).exists())
+        calibration_path, detected_joint_count = self._find_calibration(arm.arm_id)
+        calibration_found = calibration_path is not None
+
+        base = ArmVerificationState(
+            driver="lerobot",
+            dependency_available=dependency_available,
+            port_present=port_present,
+            calibration_found=calibration_found,
+            calibration_path=str(calibration_path) if calibration_path else None,
+            expected_joint_count=DEFAULT_EXPECTED_JOINT_COUNT,
+            detected_joint_count=detected_joint_count,
+            last_checked_at=datetime.now(UTC).isoformat(),
+        )
+
+        if not dependency_available:
+            return base.model_copy(
+                update={
+                    "status": ArmVerificationStatus.MISSING_DEPENDENCY,
+                    "message": "The 'lerobot' package is not installed in the backend environment.",
+                }
+            )
+
+        if serial is None:
+            return base.model_copy(
+                update={
+                    "status": ArmVerificationStatus.MISSING_DEPENDENCY,
+                    "message": "The 'pyserial' package is not installed in the backend environment.",
+                }
+            )
+
+        if not arm.port:
+            return base.model_copy(
+                update={
+                    "status": ArmVerificationStatus.MISSING_PORT,
+                    "message": f"Arm '{arm.arm_id}' has no configured serial port.",
+                }
+            )
+
+        if not port_present:
+            return base.model_copy(
+                update={
+                    "status": ArmVerificationStatus.UNREACHABLE,
+                    "message": f"Configured serial port '{arm.port}' does not exist.",
+                }
+            )
+
+        try:
+            with serial.Serial(arm.port, timeout=0.25):
+                pass
+        except (OSError, SerialException) as exc:
+            return base.model_copy(
+                update={
+                    "status": ArmVerificationStatus.UNREACHABLE,
+                    "message": f"Unable to open serial port '{arm.port}': {exc}",
+                }
+            )
+
+        if not calibration_found:
+            return base.model_copy(
+                update={
+                    "status": ArmVerificationStatus.MISSING_CALIBRATION,
+                    "message": f"No calibration file was found for arm '{arm.arm_id}'.",
+                }
+            )
+
+        if detected_joint_count < DEFAULT_EXPECTED_JOINT_COUNT:
+            return base.model_copy(
+                update={
+                    "status": ArmVerificationStatus.ERROR,
+                    "message": (
+                        f"Calibration for arm '{arm.arm_id}' only covers "
+                        f"{detected_joint_count}/{DEFAULT_EXPECTED_JOINT_COUNT} joints."
+                    ),
+                }
+            )
+
+        return base.model_copy(
+            update={
+                "status": ArmVerificationStatus.READY,
+                "message": (
+                    f"Serial port '{arm.port}' opened successfully and calibration covers "
+                    f"{detected_joint_count} joints."
+                ),
+            }
+        )
+
+    def _find_calibration(self, arm_id: str) -> tuple[Path | None, int]:
+        candidates = self._calibration_roots()
+        seen: set[Path] = set()
+        for root in candidates:
+            if root in seen or not root.exists():
+                continue
+            seen.add(root)
+            direct = self._calibration_candidate_paths(root, arm_id)
+            for candidate in direct:
+                if candidate.exists():
+                    return candidate, self._count_calibrated_joints(candidate)
+
+            for candidate in root.rglob(f"{arm_id}.json"):
+                if candidate.is_file():
+                    return candidate, self._count_calibrated_joints(candidate)
+
+        return None, 0
+
+    def _calibration_roots(self) -> list[Path]:
+        roots: list[Path] = []
+        env_calibration = os.getenv("LEROBOT_CALIBRATION_DIR")
+        if env_calibration:
+            roots.append(Path(env_calibration).expanduser())
+
+        lerobot_home = os.getenv("LEROBOT_HOME")
+        if lerobot_home:
+            roots.append(Path(lerobot_home).expanduser() / "calibration")
+
+        hf_home = os.getenv("HF_HOME")
+        if hf_home:
+            roots.append(Path(hf_home).expanduser() / "lerobot" / "calibration")
+
+        roots.append(Path.home() / ".cache" / "huggingface" / "lerobot" / "calibration")
+        roots.append(ROOT_DIR / ".data" / "calibration")
+        return roots
+
+    def _calibration_candidate_paths(self, root: Path, arm_id: str) -> list[Path]:
+        return [
+            root / f"{arm_id}.json",
+            root / "robots" / f"{arm_id}.json",
+            root / "teleoperators" / f"{arm_id}.json",
+            root / "so101_follower" / f"{arm_id}.json",
+            root / "so101_leader" / f"{arm_id}.json",
+        ]
+
+    def _count_calibrated_joints(self, path: Path) -> int:
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return 0
+
+        counts: list[int] = []
+        self._collect_joint_counts(payload, counts)
+        return max(counts, default=0)
+
+    def _collect_joint_counts(self, payload: object, counts: list[int]) -> None:
+        if isinstance(payload, dict):
+            joint_key_count = len(set(payload.keys()) & {name for _, name in DEFAULT_JOINT_LAYOUT})
+            if joint_key_count:
+                counts.append(joint_key_count)
+
+            for key in ("motors", "joints", "servos", "motors_calibration"):
+                value = payload.get(key)
+                if isinstance(value, dict):
+                    counts.append(len(value))
+                elif isinstance(value, list):
+                    counts.append(len(value))
+
+            for value in payload.values():
+                self._collect_joint_counts(value, counts)
+            return
+
+        if isinstance(payload, list):
+            if payload and all(isinstance(item, dict) for item in payload):
+                names = {str(item.get("name") or item.get("joint_name") or "") for item in payload}
+                matched_names = len(names & {name for _, name in DEFAULT_JOINT_LAYOUT})
+                if matched_names:
+                    counts.append(matched_names)
+                elif all(("id" in item or "servo_id" in item) for item in payload):
+                    counts.append(len(payload))
+            for item in payload:
+                self._collect_joint_counts(item, counts)
+
+
 class DualArmAdapter:
-    def __init__(self, config: RobotConfig) -> None:
+    def __init__(self, config: RobotConfig, verifier: LeRobotArmVerifier | None = None) -> None:
         self.execution_mode = ExecutionMode.MIRROR
         self.neutral_pose_scene = SceneName.IDLE
         self.required_dry_run = True
         self.arms: dict[str, ArmRuntime] = {}
+        self.verifier = verifier or LeRobotArmVerifier()
 
         self._register_arm(
             arm_id=config.leader_id or "leader_arm",
@@ -70,17 +265,19 @@ class DualArmAdapter:
             arm_type=arm_type,
             channel=channel,
             port=port,
-            connected=available,
-            calibrated=available,
+            connected=False,
+            calibrated=False,
             notes=self._default_note(arm_type),
             safety=self._default_safety(arm_type),
+            verification=ArmVerificationState(expected_joint_count=DEFAULT_EXPECTED_JOINT_COUNT),
             joints=self._default_joints(arm_type),
         )
+        self.verify_arm(arm_id)
 
     def _default_note(self, arm_type: ArmType) -> str:
         if arm_type == ArmType.LEADER:
-            return "Leader profile starts in conservative dry-run mode and should be recalibrated before motor writes."
-        return "Follower profile is staged for choreography playback but remains dry-run only."
+            return "Leader profile starts in conservative dry-run mode and requires live verification before motor writes."
+        return "Follower profile is staged for choreography playback and requires live verification before motor writes."
 
     def _default_safety(self, arm_type: ArmType) -> ArmSafetyEnvelope:
         if arm_type == ArmType.LEADER:
@@ -119,8 +316,11 @@ class DualArmAdapter:
         arm = self._arm(arm_id)
         if connected and not arm.port:
             raise ValueError(f"Arm '{arm_id}' has no configured port")
-        arm.connected = connected
-        if not connected:
+        if connected:
+            verification = self.verify_arm(arm_id)
+            arm.connected = verification.status == ArmVerificationStatus.READY
+        else:
+            arm.connected = False
             arm.safety.torque_enabled = False
 
     def update_safety(self, arm_id: str, payload: ArmSafetyUpdate) -> None:
@@ -153,6 +353,22 @@ class DualArmAdapter:
     def neutralize(self) -> None:
         self.neutral_pose_scene = SceneName.IDLE
 
+    def verify_all(self) -> None:
+        for arm_id in self.arms:
+            self.verify_arm(arm_id)
+
+    def verify_arm(self, arm_id: str) -> ArmVerificationState:
+        arm = self._arm(arm_id)
+        verification = self.verifier.verify(arm)
+        arm.verification = verification
+        arm.calibrated = verification.calibration_found and (
+            verification.detected_joint_count >= verification.expected_joint_count
+        )
+        arm.connected = verification.status == ArmVerificationStatus.READY
+        if verification.message:
+            arm.notes = verification.message
+        return verification
+
     def snapshot(self, choreography: ChoreographyTimeline | None, position_seconds: float) -> DualArmState:
         choreography_ready = choreography is not None
         arms: list[ArmAdapterState] = []
@@ -169,6 +385,7 @@ class DualArmAdapter:
                     calibrated=arm.calibrated,
                     safety=arm.safety.model_copy(deep=True),
                     joints=[joint.model_copy(deep=True) for joint in arm.joints],
+                    verification=arm.verification.model_copy(deep=True),
                     preview=self._preview(channel_cues, arm.channel, position_seconds),
                     notes=arm.notes,
                 )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -105,6 +105,11 @@ def get_arms() -> DualArmState:
     return store.arms_snapshot()
 
 
+@app.post("/api/arms/verify", response_model=DualArmState)
+def verify_arms() -> DualArmState:
+    return store.verify_arms()
+
+
 @app.post("/api/arms/execution-mode", response_model=DualArmState)
 def update_execution_mode(payload: ExecutionModeUpdate) -> DualArmState:
     return store.set_execution_mode(payload)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -83,6 +83,16 @@ class ExecutionMode(str, Enum):
     ASYMMETRIC = "asymmetric"
 
 
+class ArmVerificationStatus(str, Enum):
+    IDLE = "idle"
+    READY = "ready"
+    MISSING_DEPENDENCY = "missing_dependency"
+    MISSING_PORT = "missing_port"
+    UNREACHABLE = "unreachable"
+    MISSING_CALIBRATION = "missing_calibration"
+    ERROR = "error"
+
+
 class RobotConfig(BaseModel):
     assembly: str = "Follower"
     follower_id: str = "follower_arm"
@@ -160,6 +170,19 @@ class ArmSafetyEnvelope(BaseModel):
     max_step_degrees: float = Field(default=12.0, ge=1.0, le=45.0)
 
 
+class ArmVerificationState(BaseModel):
+    status: ArmVerificationStatus = ArmVerificationStatus.IDLE
+    driver: str = "dry_run"
+    dependency_available: bool = False
+    port_present: bool = False
+    calibration_found: bool = False
+    calibration_path: str | None = None
+    expected_joint_count: int = Field(default=6, ge=0)
+    detected_joint_count: int = Field(default=0, ge=0)
+    last_checked_at: str | None = None
+    message: str | None = None
+
+
 class ArmAdapterState(BaseModel):
     arm_id: str
     arm_type: ArmType
@@ -170,6 +193,7 @@ class ArmAdapterState(BaseModel):
     calibrated: bool
     safety: ArmSafetyEnvelope
     joints: list[ArmJointConfig]
+    verification: ArmVerificationState
     preview: ArmPreviewState
     notes: str | None = None
 

--- a/backend/app/state.py
+++ b/backend/app/state.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from time import monotonic
 
-from .arms import DEFAULT_JOINT_LAYOUT, DualArmAdapter
+from .arms import DEFAULT_JOINT_LAYOUT, DualArmAdapter, LeRobotArmVerifier
 from .models import (
     AnalysisStartResponse,
     AnalysisStatus,
@@ -90,9 +90,9 @@ class ServoRuntime:
 
 
 class RobotStateStore:
-    def __init__(self, config: RobotConfig | None = None) -> None:
+    def __init__(self, config: RobotConfig | None = None, verifier: LeRobotArmVerifier | None = None) -> None:
         self.config = config or self._load_config()
-        self.arm_adapter = DualArmAdapter(self.config)
+        self.arm_adapter = DualArmAdapter(self.config, verifier=verifier)
         self.mode = DanceMode.IDLE
         self.transport = TransportState()
         self.status = "ready"
@@ -386,6 +386,11 @@ class RobotStateStore:
     def arms_snapshot(self) -> DualArmState:
         self._tick()
         return self.arm_adapter.snapshot(self.current_choreography(), self.transport.position_seconds)
+
+    def verify_arms(self) -> DualArmState:
+        self.arm_adapter.verify_all()
+        self._sync_follower_torque_state()
+        return self.arms_snapshot()
 
     def set_execution_mode(self, payload: ExecutionModeUpdate) -> DualArmState:
         self.arm_adapter.set_execution_mode(payload.mode)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ numpy>=2.2,<3.0
 scipy>=1.15,<2.0
 librosa>=0.11,<1.0
 soundfile>=0.13,<1.0
+pyserial>=3.5,<4.0

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -12,9 +12,26 @@ from fastapi.testclient import TestClient
 
 from backend.app import main as main_module
 from backend.app.analysis import AudioAnalysisCache, AudioAnalysisService
+from backend.app.arms import DEFAULT_EXPECTED_JOINT_COUNT, ArmRuntime
 from backend.app.music import JamendoTrackProvider, LocalTrackLibrary
-from backend.app.models import RobotConfig
+from backend.app.models import ArmVerificationState, ArmVerificationStatus, RobotConfig
 from backend.app.state import RobotStateStore
+
+
+class FakeReadyVerifier:
+    def verify(self, arm: ArmRuntime) -> ArmVerificationState:
+        return ArmVerificationState(
+            status=ArmVerificationStatus.READY,
+            driver="test-double",
+            dependency_available=True,
+            port_present=True,
+            calibration_found=True,
+            calibration_path=f"/tmp/{arm.arm_id}.json",
+            expected_joint_count=DEFAULT_EXPECTED_JOINT_COUNT,
+            detected_joint_count=DEFAULT_EXPECTED_JOINT_COUNT,
+            last_checked_at="2026-03-31T00:00:00+00:00",
+            message=f"{arm.arm_id} verified for tests",
+        )
 
 
 class ApiSmokeTest(unittest.TestCase):
@@ -35,7 +52,8 @@ class ApiSmokeTest(unittest.TestCase):
                 leader_id="test_leader",
                 leader_port="/dev/mock-leader",
                 safety_step_ticks=120,
-            )
+            ),
+            verifier=FakeReadyVerifier(),
         )
         main_module.local_library = LocalTrackLibrary(
             uploads_dir=uploads_root,
@@ -118,6 +136,15 @@ class ApiSmokeTest(unittest.TestCase):
             {arm["arm_type"] for arm in arms_payload["arms"]},
             {"leader", "follower"},
         )
+        self.assertTrue(all(arm["verification"]["status"] == "ready" for arm in arms_payload["arms"]))
+        self.assertTrue(all(arm["verification"]["detected_joint_count"] == 6 for arm in arms_payload["arms"]))
+
+        verify = self.client.post("/api/arms/verify")
+        self.assertEqual(verify.status_code, 200)
+        verify_payload = verify.json()
+        self.assertTrue(all(arm["connected"] for arm in verify_payload["arms"]))
+        self.assertTrue(all(arm["calibrated"] for arm in verify_payload["arms"]))
+        self.assertTrue(all(arm["verification"]["driver"] == "test-double" for arm in verify_payload["arms"]))
 
         mode_update = self.client.post("/api/arms/execution-mode", json={"mode": "call_response"})
         self.assertEqual(mode_update.status_code, 200)

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -82,6 +82,20 @@ These contracts started ahead of the implementation. The real backend analysis p
 ### `GET /api/arms`
 - Response: `DualArmState`
 
+### `POST /api/arms/verify`
+- Triggers live verification for both configured arms
+- Response: `DualArmState`
+- Each arm now includes:
+  - `verification.status`
+  - `verification.driver`
+  - `verification.port_present`
+  - `verification.calibration_found`
+  - `verification.calibration_path`
+  - `verification.expected_joint_count`
+  - `verification.detected_joint_count`
+  - `verification.last_checked_at`
+  - `verification.message`
+
 ### `POST /api/arms/execution-mode`
 - Body:
 ```json
@@ -99,6 +113,7 @@ These contracts started ahead of the implementation. The real backend analysis p
 }
 ```
 - Response: `DualArmState`
+- Connecting an arm now refreshes its verification state before marking it connected
 
 ### `POST /api/arms/{arm_id}/safety`
 - Body:
@@ -138,6 +153,18 @@ These contracts started ahead of the implementation. The real backend analysis p
 - `audio_url`
 - `external_url`
 - `analysis_status`
+
+### `ArmVerificationState`
+- `status`
+- `driver`
+- `dependency_available`
+- `port_present`
+- `calibration_found`
+- `calibration_path`
+- `expected_joint_count`
+- `detected_joint_count`
+- `last_checked_at`
+- `message`
 - `motion_profile`
 
 ### `AudioAnalysis`

--- a/docs/IMPLEMENTATION_TRACKER.md
+++ b/docs/IMPLEMENTATION_TRACKER.md
@@ -9,7 +9,7 @@ The delivery sequence is:
 - Phase 3: optional leader-arm capture, phrase authoring, and smarter choreography tools
 
 ## Active Epic
-- `#18` Phase 1: music analysis console for dual-arm SO-101 dance system
+- `#28` Phase 2: real dual-arm SO-101 execution for leader + follower
 
 ## Ticket Stack
 - `#10` Define audio analysis models and API contracts for dual-arm choreography [done]
@@ -22,9 +22,15 @@ The delivery sequence is:
 - `#17` Prepare dual-arm LeRobot adapter and safety envelope [done]
 - `#19` Add GitHub Actions CI for backend, frontend, and smoke validation
 - `#20` Dockerize frontend and backend with docker compose startup
+- `#29` Verify live SO-101 connection and calibration loading for both arms
+- `#31` Implement real dual-arm SO-101 hardware bridge and telemetry
+- `#30` Enforce live safety supervisor for torque, neutral, emergency stop, and step limits
+- `#32` Add manual hardware validation controls and status surfaces
+- `#34` Execute choreography on one live SO-101 arm
+- `#33` Run synchronized dual-arm choreography playback on leader + follower
 
 ## Current Status
-- Current PR target: `#15`
+- Current PR target: `#29`
 - Current backend state:
   - Search and track selection exist
   - Local upload and persistent local track metadata are available
@@ -33,12 +39,14 @@ The delivery sequence is:
   - Dual-arm choreography output is section-aware and exposes left/right arm cue channels
   - `/api/state` now derives transport BPM, energy, spectrum bars, and autonomous servo modulation from cached analysis when it exists
   - Dual-arm adapter profiles now exist for leader + follower with dry-run defaults, safety envelopes, execution modes, and emergency-stop/neutral planning endpoints
+  - `#29` is wiring live readiness checks for dependency availability, serial-port reachability, and calibration coverage per arm
 - Current frontend state:
   - Home page is music-first
   - Search/select flow exists
   - Minimal local upload/select flow exists without redesigning the page
   - Waveform is now the primary playback surface through `wavesurfer.js`
   - Spectrogram, rhythm, structure, and track-info tabs are wired to the real backend analysis payload
+  - Live hardware execution is not implemented yet; the current dual-arm adapter remains dry-run only
 
 ## Workflow Rule
 - Each ticket must ship from a feature branch through a pull request.
@@ -47,21 +55,19 @@ The delivery sequence is:
 
 ## Working Decisions
 - Use Python backend as the source of truth for BPM, beats, sections, and choreography timeline.
-- Keep leader and follower as separate hardware profiles even if they share motor family overlap.
+- For Phase 2 planning, treat leader and follower as the same calibrated 6-joint SO-101 control profile while still preserving separate ports, safety state, and runtime status.
 - Keep current search/select compatibility while expanding schema.
 - Do not fake real analysis results in contract tickets. Contract endpoints may exist before the implementation behind them.
 - Persist local upload metadata under `.data/uploads/index.json` and keep uploaded media files under `.data/uploads/files/`.
 - Persist computed audio analysis under `.data/analysis-cache/json/` and remote source audio under `.data/analysis-cache/audio/`.
 
 ## PR Order
-1. `#10` Data models and API contracts
-2. `#11` Local upload pipeline
-3. `#12` Audio analysis pipeline
-4. `#13` Choreography timeline generation
-5. `#14` Waveform-first frontend
-6. `#15` Analysis tabs
-7. `#16` Remove synthetic state as source of truth
-8. `#17` Dual-arm hardware adapter prep
+1. `#29` Live connection and calibration verification
+2. `#31` Real hardware bridge and telemetry
+3. `#30` Live safety supervisor
+4. `#32` Manual hardware validation controls
+5. `#34` Single-arm live choreography execution
+6. `#33` Dual-arm synchronized live choreography playback
 
 ## Update Rule
 After each merged PR:

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -9,6 +9,14 @@ export type SymmetryRole = "lead" | "follow" | "mirror" | "unison" | "contrast";
 export type ArmType = "follower" | "leader";
 export type ArmChannel = "left" | "right";
 export type ExecutionMode = "mirror" | "unison" | "call_response" | "asymmetric";
+export type ArmVerificationStatus =
+  | "idle"
+  | "ready"
+  | "missing_dependency"
+  | "missing_port"
+  | "unreachable"
+  | "missing_calibration"
+  | "error";
 
 export interface RobotConfig {
   assembly: string;
@@ -183,6 +191,19 @@ export interface ArmSafetyEnvelope {
   max_step_degrees: number;
 }
 
+export interface ArmVerificationState {
+  status: ArmVerificationStatus;
+  driver: string;
+  dependency_available: boolean;
+  port_present: boolean;
+  calibration_found: boolean;
+  calibration_path?: string | null;
+  expected_joint_count: number;
+  detected_joint_count: number;
+  last_checked_at?: string | null;
+  message?: string | null;
+}
+
 export interface ArmAdapterState {
   arm_id: string;
   arm_type: ArmType;
@@ -193,6 +214,7 @@ export interface ArmAdapterState {
   calibrated: boolean;
   safety: ArmSafetyEnvelope;
   joints: ArmJointConfig[];
+  verification: ArmVerificationState;
   preview: ArmPreviewState;
   notes?: string | null;
 }


### PR DESCRIPTION
Closes #29

## Summary
- add live arm verification state for dependency availability, serial-port reachability, and calibration coverage
- expose POST /api/arms/verify and refresh verification on connect
- document the new readiness surface and cover it with backend smoke tests

## Verification
- python3 -m compileall backend/app
- backend/.venv/bin/python -m unittest discover -s backend/tests -v
- npm run build
- runtime probe: POST /api/arms/verify returned ready for both configured arms on this machine
