### PR TITLE
feat: add live dual-arm telemetry bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,13 @@ The backend now exposes a dry-run dual-arm execution surface for your SO-101 lea
 
 - `GET /api/arms` returns concrete adapter profiles for `leader` and `follower`
 - `POST /api/arms/verify` checks dependency availability, serial-port reachability, and calibration coverage for both arms
+- `POST /api/arms/{arm_id}/connect` now opens a real read-only telemetry session for the selected arm
 - `POST /api/arms/execution-mode` switches between `mirror`, `unison`, `call_response`, and `asymmetric`
 - `POST /api/arms/{arm_id}/safety` updates per-arm dry-run/safety settings plus joint overrides for offsets, inversion, limits, and speed caps
 - `POST /api/arms/emergency-stop` disables torque in the adapter layer before any real motor writes are attempted
 - `POST /api/arms/neutral` moves the planning state back to the neutral scene
 
-This is still a planning and validation layer. It does not write choreography to real hardware yet, but it now reports whether each arm is actually ready for the live execution phase.
+This is still a planning and validation layer for motion writes. It does not send choreography to real hardware yet, but it now opens real SO-101 read-only telemetry sessions and reports live joint values for each arm.
 
 Install or refresh backend dependencies after pulling:
 
@@ -118,6 +119,8 @@ cd backend
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
+
+The backend requirements now include `feetech-servo-sdk`, which LeRobot needs for Feetech/STS telemetry.
 
 ## Docker
 

--- a/backend/app/arms.py
+++ b/backend/app/arms.py
@@ -6,6 +6,7 @@ import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, Protocol
 
 try:
     import serial
@@ -34,6 +35,7 @@ from .models import (
     MotionCue,
     RobotConfig,
     SceneName,
+    ServoState,
 )
 
 DEFAULT_JOINT_LAYOUT = [
@@ -50,6 +52,14 @@ DEFAULT_EXPECTED_JOINT_COUNT = len(DEFAULT_JOINT_LAYOUT)
 
 
 @dataclass
+class ArmTelemetryRuntime:
+    live: bool = False
+    updated_at: str | None = None
+    error: str | None = None
+    servos: list[ServoState] = field(default_factory=list)
+
+
+@dataclass
 class ArmRuntime:
     arm_id: str
     arm_type: ArmType
@@ -60,6 +70,7 @@ class ArmRuntime:
     notes: str
     safety: ArmSafetyEnvelope
     verification: ArmVerificationState
+    telemetry: ArmTelemetryRuntime = field(default_factory=ArmTelemetryRuntime)
     joints: list[ArmJointConfig] = field(default_factory=list)
 
 
@@ -194,6 +205,8 @@ class LeRobotArmVerifier:
             root / f"{arm_id}.json",
             root / "robots" / f"{arm_id}.json",
             root / "teleoperators" / f"{arm_id}.json",
+            root / "so_follower" / f"{arm_id}.json",
+            root / "so_leader" / f"{arm_id}.json",
             root / "so101_follower" / f"{arm_id}.json",
             root / "so101_leader" / f"{arm_id}.json",
         ]
@@ -237,13 +250,119 @@ class LeRobotArmVerifier:
                 self._collect_joint_counts(item, counts)
 
 
+class ArmHardwareBridge(Protocol):
+    def connect(self, arm: ArmRuntime) -> None: ...
+
+    def disconnect(self, arm: ArmRuntime) -> None: ...
+
+    def is_connected(self, arm: ArmRuntime) -> bool: ...
+
+    def read_telemetry(self, arm: ArmRuntime) -> list[ServoState]: ...
+
+
+@dataclass
+class LeRobotBusSession:
+    owner: Any
+    bus: Any
+
+
+class LeRobotHardwareBridge:
+    def __init__(self) -> None:
+        self.sessions: dict[str, LeRobotBusSession] = {}
+
+    def connect(self, arm: ArmRuntime) -> None:
+        if arm.arm_id in self.sessions:
+            return
+        session = self._build_session(arm)
+        self.sessions[arm.arm_id] = session
+
+    def disconnect(self, arm: ArmRuntime) -> None:
+        session = self.sessions.pop(arm.arm_id, None)
+        if session is None:
+            return
+        if session.bus.is_connected:
+            session.bus.disconnect(disable_torque=False)
+
+    def is_connected(self, arm: ArmRuntime) -> bool:
+        session = self.sessions.get(arm.arm_id)
+        return bool(session and session.bus.is_connected)
+
+    def read_telemetry(self, arm: ArmRuntime) -> list[ServoState]:
+        session = self.sessions.get(arm.arm_id)
+        if session is None:
+            raise RuntimeError(f"Arm '{arm.arm_id}' is not connected for telemetry")
+
+        bus = session.bus
+        positions = bus.sync_read("Present_Position")
+        goals = bus.sync_read("Goal_Position")
+        loads = bus.sync_read("Present_Load")
+        temperatures = bus.sync_read("Present_Temperature")
+        moving = bus.sync_read("Moving")
+        torque = bus.sync_read("Torque_Enable")
+
+        return [
+            ServoState(
+                id=servo_id,
+                name=joint_name,
+                angle=round(float(positions.get(joint_name, 0.0)), 2),
+                target_angle=round(float(goals.get(joint_name, positions.get(joint_name, 0.0))), 2),
+                torque_enabled=bool(torque.get(joint_name, 0)),
+                temperature_c=round(float(temperatures.get(joint_name, 0.0)), 1),
+                load_pct=round(self._normalize_load(loads.get(joint_name, 0.0)), 1),
+                motion_phase="ramping" if bool(moving.get(joint_name, 0)) else "steady",
+            )
+            for servo_id, joint_name in DEFAULT_JOINT_LAYOUT
+        ]
+
+    def _build_session(self, arm: ArmRuntime) -> LeRobotBusSession:
+        if not arm.port:
+            raise RuntimeError(f"Arm '{arm.arm_id}' has no configured serial port")
+
+        if arm.arm_type == ArmType.FOLLOWER:
+            from lerobot.robots.so_follower.config_so_follower import SOFollowerRobotConfig
+            from lerobot.robots.so_follower.so_follower import SOFollower
+
+            robot = SOFollower(
+                SOFollowerRobotConfig(
+                    id=arm.arm_id,
+                    port=arm.port,
+                    cameras={},
+                    use_degrees=True,
+                )
+            )
+            robot.bus.connect(handshake=True)
+            return LeRobotBusSession(owner=robot, bus=robot.bus)
+
+        from lerobot.teleoperators.so_leader.config_so_leader import SOLeaderTeleopConfig
+        from lerobot.teleoperators.so_leader.so_leader import SOLeader
+
+        teleoperator = SOLeader(
+            SOLeaderTeleopConfig(
+                id=arm.arm_id,
+                port=arm.port,
+                use_degrees=True,
+            )
+        )
+        teleoperator.bus.connect(handshake=True)
+        return LeRobotBusSession(owner=teleoperator, bus=teleoperator.bus)
+
+    def _normalize_load(self, value: float) -> float:
+        return max(0.0, min(100.0, abs(float(value)) / 10.0))
+
+
 class DualArmAdapter:
-    def __init__(self, config: RobotConfig, verifier: LeRobotArmVerifier | None = None) -> None:
+    def __init__(
+        self,
+        config: RobotConfig,
+        verifier: LeRobotArmVerifier | None = None,
+        bridge: ArmHardwareBridge | None = None,
+    ) -> None:
         self.execution_mode = ExecutionMode.MIRROR
         self.neutral_pose_scene = SceneName.IDLE
         self.required_dry_run = True
         self.arms: dict[str, ArmRuntime] = {}
         self.verifier = verifier or LeRobotArmVerifier()
+        self.bridge = bridge or LeRobotHardwareBridge()
 
         self._register_arm(
             arm_id=config.leader_id or "leader_arm",
@@ -259,7 +378,6 @@ class DualArmAdapter:
         )
 
     def _register_arm(self, arm_id: str, arm_type: ArmType, channel: ArmChannel, port: str | None) -> None:
-        available = bool(port)
         self.arms[arm_id] = ArmRuntime(
             arm_id=arm_id,
             arm_type=arm_type,
@@ -276,8 +394,8 @@ class DualArmAdapter:
 
     def _default_note(self, arm_type: ArmType) -> str:
         if arm_type == ArmType.LEADER:
-            return "Leader profile starts in conservative dry-run mode and requires live verification before motor writes."
-        return "Follower profile is staged for choreography playback and requires live verification before motor writes."
+            return "Leader profile is read-only until live motion support is added."
+        return "Follower profile is read-only until live motion support is added."
 
     def _default_safety(self, arm_type: ArmType) -> ArmSafetyEnvelope:
         if arm_type == ArmType.LEADER:
@@ -304,7 +422,7 @@ class DualArmAdapter:
         return joints
 
     def any_connected(self) -> bool:
-        return any(arm.connected for arm in self.arms.values())
+        return any(self.bridge.is_connected(arm) for arm in self.arms.values())
 
     def emergency_stop_active(self) -> bool:
         return any(arm.safety.emergency_stop for arm in self.arms.values())
@@ -316,12 +434,32 @@ class DualArmAdapter:
         arm = self._arm(arm_id)
         if connected and not arm.port:
             raise ValueError(f"Arm '{arm_id}' has no configured port")
+
         if connected:
             verification = self.verify_arm(arm_id)
-            arm.connected = verification.status == ArmVerificationStatus.READY
-        else:
-            arm.connected = False
-            arm.safety.torque_enabled = False
+            if verification.status != ArmVerificationStatus.READY:
+                raise ValueError(verification.message or f"Arm '{arm_id}' is not ready for live telemetry")
+
+            try:
+                self.bridge.connect(arm)
+                arm.connected = self.bridge.is_connected(arm)
+                self.refresh_telemetry(arm_id)
+                arm.notes = f"{arm.arm_id} is streaming live telemetry."
+            except Exception as exc:
+                arm.connected = False
+                arm.telemetry.live = False
+                arm.telemetry.error = str(exc)
+                arm.notes = f"Live telemetry connection failed: {exc}"
+                raise ValueError(arm.notes) from exc
+            return
+
+        self.bridge.disconnect(arm)
+        arm.connected = False
+        arm.telemetry.live = False
+        arm.telemetry.error = None
+        arm.telemetry.updated_at = None
+        arm.telemetry.servos = []
+        arm.notes = self._default_note(arm.arm_type)
 
     def update_safety(self, arm_id: str, payload: ArmSafetyUpdate) -> None:
         arm = self._arm(arm_id)
@@ -364,15 +502,52 @@ class DualArmAdapter:
         arm.calibrated = verification.calibration_found and (
             verification.detected_joint_count >= verification.expected_joint_count
         )
-        arm.connected = verification.status == ArmVerificationStatus.READY
+        if not self.bridge.is_connected(arm):
+            arm.connected = False
         if verification.message:
             arm.notes = verification.message
         return verification
+
+    def refresh_all_telemetry(self) -> None:
+        for arm_id in self.arms:
+            if self.arms[arm_id].connected:
+                self.refresh_telemetry(arm_id)
+
+    def refresh_telemetry(self, arm_id: str) -> list[ServoState]:
+        arm = self._arm(arm_id)
+        if not self.bridge.is_connected(arm):
+            arm.connected = False
+            arm.telemetry.live = False
+            arm.telemetry.error = "Arm is not connected for live telemetry."
+            arm.telemetry.servos = []
+            return []
+
+        try:
+            servos = self.bridge.read_telemetry(arm)
+        except Exception as exc:
+            self.bridge.disconnect(arm)
+            arm.connected = False
+            arm.telemetry.live = False
+            arm.telemetry.error = str(exc)
+            arm.telemetry.updated_at = datetime.now(UTC).isoformat()
+            arm.telemetry.servos = []
+            arm.notes = f"Telemetry read failed: {exc}"
+            return []
+
+        arm.connected = True
+        arm.telemetry.live = True
+        arm.telemetry.error = None
+        arm.telemetry.updated_at = datetime.now(UTC).isoformat()
+        arm.telemetry.servos = servos
+        return servos
 
     def snapshot(self, choreography: ChoreographyTimeline | None, position_seconds: float) -> DualArmState:
         choreography_ready = choreography is not None
         arms: list[ArmAdapterState] = []
         for arm in self.arms.values():
+            if arm.connected:
+                self.refresh_telemetry(arm.arm_id)
+
             channel_cues = self._channel_cues(choreography, arm.channel)
             arms.append(
                 ArmAdapterState(
@@ -386,6 +561,10 @@ class DualArmAdapter:
                     safety=arm.safety.model_copy(deep=True),
                     joints=[joint.model_copy(deep=True) for joint in arm.joints],
                     verification=arm.verification.model_copy(deep=True),
+                    telemetry_live=arm.telemetry.live,
+                    telemetry_updated_at=arm.telemetry.updated_at,
+                    telemetry_error=arm.telemetry.error,
+                    telemetry=[servo.model_copy(deep=True) for servo in arm.telemetry.servos],
                     preview=self._preview(channel_cues, arm.channel, position_seconds),
                     notes=arm.notes,
                 )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -194,6 +194,10 @@ class ArmAdapterState(BaseModel):
     safety: ArmSafetyEnvelope
     joints: list[ArmJointConfig]
     verification: ArmVerificationState
+    telemetry_live: bool = False
+    telemetry_updated_at: str | None = None
+    telemetry_error: str | None = None
+    telemetry: list[ServoState] = Field(default_factory=list)
     preview: ArmPreviewState
     notes: str | None = None
 

--- a/backend/app/state.py
+++ b/backend/app/state.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from time import monotonic
 
-from .arms import DEFAULT_JOINT_LAYOUT, DualArmAdapter, LeRobotArmVerifier
+from .arms import ArmHardwareBridge, DEFAULT_JOINT_LAYOUT, DualArmAdapter, LeRobotArmVerifier
 from .models import (
     AnalysisStartResponse,
     AnalysisStatus,
@@ -90,9 +90,14 @@ class ServoRuntime:
 
 
 class RobotStateStore:
-    def __init__(self, config: RobotConfig | None = None, verifier: LeRobotArmVerifier | None = None) -> None:
+    def __init__(
+        self,
+        config: RobotConfig | None = None,
+        verifier: LeRobotArmVerifier | None = None,
+        bridge: ArmHardwareBridge | None = None,
+    ) -> None:
         self.config = config or self._load_config()
-        self.arm_adapter = DualArmAdapter(self.config, verifier=verifier)
+        self.arm_adapter = DualArmAdapter(self.config, verifier=verifier, bridge=bridge)
         self.mode = DanceMode.IDLE
         self.transport = TransportState()
         self.status = "ready"
@@ -220,6 +225,7 @@ class RobotStateStore:
         connected = self.arm_adapter.any_connected()
         spectrum = self._build_spectrum()
         dual_arm = self.arm_adapter.snapshot(self.current_choreography(), self.transport.position_seconds)
+        public_servos = self._public_servos(dual_arm)
         return RobotState(
             connected=connected,
             status=self.status,
@@ -234,19 +240,7 @@ class RobotStateStore:
             last_sync=datetime.now(UTC).isoformat(),
             transport=self.transport,
             spectrum=spectrum,
-            servos=[
-                ServoState(
-                    id=servo.id,
-                    name=servo.name,
-                    angle=round(servo.angle, 2),
-                    target_angle=round(servo.target_angle, 2),
-                    torque_enabled=servo.torque_enabled,
-                    temperature_c=round(servo.temperature_c, 1),
-                    load_pct=round(servo.load_pct, 1),
-                    motion_phase=servo.motion_phase,
-                )
-                for servo in self.servos
-            ],
+            servos=public_servos,
             dual_arm=dual_arm,
         )
 
@@ -564,6 +558,25 @@ class RobotStateStore:
         torque_enabled = follower.safety.torque_enabled and not follower.safety.emergency_stop
         for servo in self.servos:
             servo.torque_enabled = torque_enabled
+
+    def _public_servos(self, dual_arm: DualArmState) -> list[ServoState]:
+        follower = next((arm for arm in dual_arm.arms if arm.arm_type == "follower"), None)
+        if follower and follower.telemetry_live and follower.telemetry:
+            return [servo.model_copy(deep=True) for servo in follower.telemetry]
+
+        return [
+            ServoState(
+                id=servo.id,
+                name=servo.name,
+                angle=round(servo.angle, 2),
+                target_angle=round(servo.target_angle, 2),
+                torque_enabled=servo.torque_enabled,
+                temperature_c=round(servo.temperature_c, 1),
+                load_pct=round(servo.load_pct, 1),
+                motion_phase=servo.motion_phase,
+            )
+            for servo in self.servos
+        ]
 
     def _servo_driver(
         self,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ scipy>=1.15,<2.0
 librosa>=0.11,<1.0
 soundfile>=0.13,<1.0
 pyserial>=3.5,<4.0
+feetech-servo-sdk>=1.0.0,<2.0.0

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -14,7 +14,7 @@ from backend.app import main as main_module
 from backend.app.analysis import AudioAnalysisCache, AudioAnalysisService
 from backend.app.arms import DEFAULT_EXPECTED_JOINT_COUNT, ArmRuntime
 from backend.app.music import JamendoTrackProvider, LocalTrackLibrary
-from backend.app.models import ArmVerificationState, ArmVerificationStatus, RobotConfig
+from backend.app.models import ArmVerificationState, ArmVerificationStatus, RobotConfig, ServoState
 from backend.app.state import RobotStateStore
 
 
@@ -32,6 +32,47 @@ class FakeReadyVerifier:
             last_checked_at="2026-03-31T00:00:00+00:00",
             message=f"{arm.arm_id} verified for tests",
         )
+
+
+DEFAULT_SERVO_LAYOUT = [
+    (1, "shoulder_pan"),
+    (2, "shoulder_lift"),
+    (3, "elbow_flex"),
+    (4, "wrist_flex"),
+    (5, "wrist_roll"),
+    (6, "gripper"),
+]
+
+
+class FakeTelemetryBridge:
+    def __init__(self) -> None:
+        self.connected: set[str] = set()
+
+    def connect(self, arm: ArmRuntime) -> None:
+        self.connected.add(arm.arm_id)
+
+    def disconnect(self, arm: ArmRuntime) -> None:
+        self.connected.discard(arm.arm_id)
+
+    def is_connected(self, arm: ArmRuntime) -> bool:
+        return arm.arm_id in self.connected
+
+    def read_telemetry(self, arm: ArmRuntime) -> list[ServoState]:
+        base = 10.0 if arm.arm_type == "leader" else 20.0
+        torque_enabled = arm.safety.torque_enabled and not arm.safety.emergency_stop
+        return [
+            ServoState(
+                id=servo_id,
+                name=name,
+                angle=base + servo_id,
+                target_angle=base + servo_id + 0.5,
+                torque_enabled=torque_enabled,
+                temperature_c=32.0 + servo_id,
+                load_pct=10.0 + servo_id,
+                motion_phase="ramping" if servo_id % 2 else "steady",
+            )
+            for servo_id, name in DEFAULT_SERVO_LAYOUT
+        ]
 
 
 class ApiSmokeTest(unittest.TestCase):
@@ -54,6 +95,7 @@ class ApiSmokeTest(unittest.TestCase):
                 safety_step_ticks=120,
             ),
             verifier=FakeReadyVerifier(),
+            bridge=FakeTelemetryBridge(),
         )
         main_module.local_library = LocalTrackLibrary(
             uploads_dir=uploads_root,
@@ -142,9 +184,27 @@ class ApiSmokeTest(unittest.TestCase):
         verify = self.client.post("/api/arms/verify")
         self.assertEqual(verify.status_code, 200)
         verify_payload = verify.json()
-        self.assertTrue(all(arm["connected"] for arm in verify_payload["arms"]))
+        self.assertTrue(all(not arm["connected"] for arm in verify_payload["arms"]))
         self.assertTrue(all(arm["calibrated"] for arm in verify_payload["arms"]))
         self.assertTrue(all(arm["verification"]["driver"] == "test-double" for arm in verify_payload["arms"]))
+
+        connect_leader = self.client.post("/api/arms/test_leader/connect", json={"connected": True})
+        self.assertEqual(connect_leader.status_code, 200)
+        leader_live = next(arm for arm in connect_leader.json()["arms"] if arm["arm_id"] == "test_leader")
+        self.assertTrue(leader_live["connected"])
+        self.assertTrue(leader_live["telemetry_live"])
+        self.assertEqual(len(leader_live["telemetry"]), 6)
+
+        connect_follower = self.client.post("/api/arms/test_follower/connect", json={"connected": True})
+        self.assertEqual(connect_follower.status_code, 200)
+        follower_live = next(arm for arm in connect_follower.json()["arms"] if arm["arm_id"] == "test_follower")
+        self.assertTrue(follower_live["connected"])
+        self.assertTrue(follower_live["telemetry_live"])
+        self.assertEqual(follower_live["telemetry"][0]["name"], "shoulder_pan")
+
+        state_with_live = self.client.get("/api/state")
+        self.assertEqual(state_with_live.status_code, 200)
+        self.assertEqual(state_with_live.json()["servos"][0]["angle"], 21.0)
 
         mode_update = self.client.post("/api/arms/execution-mode", json={"mode": "call_response"})
         self.assertEqual(mode_update.status_code, 200)

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -113,7 +113,8 @@ These contracts started ahead of the implementation. The real backend analysis p
 }
 ```
 - Response: `DualArmState`
-- Connecting an arm now refreshes its verification state before marking it connected
+- Connecting an arm now refreshes verification and opens a live read-only telemetry session through LeRobot/Feetech
+- `connected=true` now means an active bus session is open, not just that verification passed
 
 ### `POST /api/arms/{arm_id}/safety`
 - Body:
@@ -216,6 +217,11 @@ These contracts started ahead of the implementation. The real backend analysis p
 - `calibrated`
 - `safety`
 - `joints`
+- `verification`
+- `telemetry_live`
+- `telemetry_updated_at`
+- `telemetry_error`
+- `telemetry`
 - `preview`
 - `notes`
 
@@ -227,3 +233,4 @@ These contracts started ahead of the implementation. The real backend analysis p
 - Analysis results are cached on disk under `.data/analysis-cache/` keyed by `source + track_id`.
 - `AudioAnalysis.choreography` exposes the timeline consumed by the dual-arm adapter preview.
 - `GET /api/state` now returns a `dual_arm` block in addition to the legacy single-arm servo view so the frontend can evolve without breaking existing responses.
+- When a follower live session is open, the legacy `servos` list now reflects real follower telemetry instead of the synthetic fallback values.

--- a/docs/IMPLEMENTATION_TRACKER.md
+++ b/docs/IMPLEMENTATION_TRACKER.md
@@ -22,15 +22,15 @@ The delivery sequence is:
 - `#17` Prepare dual-arm LeRobot adapter and safety envelope [done]
 - `#19` Add GitHub Actions CI for backend, frontend, and smoke validation
 - `#20` Dockerize frontend and backend with docker compose startup
-- `#29` Verify live SO-101 connection and calibration loading for both arms
+- `#29` Verify live SO-101 connection and calibration loading for both arms [done]
 - `#31` Implement real dual-arm SO-101 hardware bridge and telemetry
 - `#30` Enforce live safety supervisor for torque, neutral, emergency stop, and step limits
-- `#32` Add manual hardware validation controls and status surfaces
+- `#32` Add manual hardware validation controls and status surfaces [done]
 - `#34` Execute choreography on one live SO-101 arm
 - `#33` Run synchronized dual-arm choreography playback on leader + follower
 
 ## Current Status
-- Current PR target: `#32`
+- Current PR target: `#31`
 - Current backend state:
   - Search and track selection exist
   - Local upload and persistent local track metadata are available
@@ -39,15 +39,19 @@ The delivery sequence is:
   - Dual-arm choreography output is section-aware and exposes left/right arm cue channels
   - `/api/state` now derives transport BPM, energy, spectrum bars, and autonomous servo modulation from cached analysis when it exists
   - Dual-arm adapter profiles now exist for leader + follower with dry-run defaults, safety envelopes, execution modes, and emergency-stop/neutral planning endpoints
-  - `#29` is wiring live readiness checks for dependency availability, serial-port reachability, and calibration coverage per arm
+  - `#29` now verifies dependency availability, serial-port reachability, and calibration coverage per arm
+  - `#31` now opens real read-only LeRobot/Feetech sessions for leader + follower and exposes live joint telemetry in `/api/state` and `/api/arms`
+  - Active bus sessions are now distinct from verification-ready state; `connected=true` means a live telemetry session is open
+  - The backend now requires `feetech-servo-sdk` for real SO-101 telemetry through LeRobot
 - Current frontend state:
   - Home page is music-first
   - Search/select flow exists
   - Minimal local upload/select flow exists without redesigning the page
   - Waveform is now the primary playback surface through `wavesurfer.js`
   - Spectrogram, rhythm, structure, and track-info tabs are wired to the real backend analysis payload
-  - Hardware dashboard work is in progress for arm readiness, joint visibility, and operator validation status
-  - Live hardware execution is not implemented yet; the current dual-arm adapter remains dry-run only
+  - Hardware dashboard now separates verification-ready state from active telemetry state
+  - Robot dashboard now shows real per-arm telemetry once a live connection is opened
+  - Live hardware execution is not implemented yet; the current dual-arm adapter remains read-only/dry-run for writes
 
 ## Workflow Rule
 - Each ticket must ship from a feature branch through a pull request.

--- a/frontend/src/components/hardware/hardware-status-dashboard.tsx
+++ b/frontend/src/components/hardware/hardware-status-dashboard.tsx
@@ -72,12 +72,11 @@ export function HardwareStatusDashboard({
 }) {
   const arms = state?.dual_arm.arms ?? [];
   const execution = state?.dual_arm.execution;
-  const servos = state?.servos ?? [];
-  const liveServoState = servoRuntimeMap(servos);
   const connectedCount = arms.filter((arm) => arm.connected).length;
   const readyCount = arms.filter((arm) => arm.verification.status === "ready").length;
+  const allTelemetry = arms.flatMap((arm) => arm.telemetry);
   const averageLoad =
-    servos.length > 0 ? servos.reduce((sum, servo) => sum + servo.load_pct, 0) / servos.length : 0;
+    allTelemetry.length > 0 ? allTelemetry.reduce((sum, servo) => sum + servo.load_pct, 0) / allTelemetry.length : 0;
 
   return (
     <section className="grid gap-6">
@@ -86,7 +85,7 @@ export function HardwareStatusDashboard({
           <div>
             <div className="flex flex-wrap items-center gap-3">
               <Badge>Hardware Readiness</Badge>
-              <Badge variant="muted">{loading ? "Refreshing" : "Live State"}</Badge>
+              <Badge variant="muted">{loading ? "Refreshing" : "Telemetry Ready"}</Badge>
               <Badge variant="accent">{execution?.dry_run_required ? "Dry Run Required" : "Live Ready"}</Badge>
             </div>
             <CardTitle className="mt-4 text-3xl text-white">Arm and Motor Dashboard</CardTitle>
@@ -117,52 +116,23 @@ export function HardwareStatusDashboard({
           <CardHeader>
             <CardTitle className="text-white">Live Motor Bus</CardTitle>
             <CardDescription className="text-slate-300">
-              The current runtime state for the 6-motor execution bus: name, target, angle, load, heat, and torque.
+              Real motor telemetry appears only after a live arm connection is opened. Verification alone does not
+              stream joint values.
             </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-3">
-            {servos.map((servo) => (
-              <div
-                key={servo.id}
-                className="rounded-[22px] border border-white/10 bg-black/25 p-4 shadow-[0_12px_34px_rgba(2,8,23,0.24)]"
-              >
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-3">
-                      <Badge variant="muted">Servo {servo.id}</Badge>
-                      <p className="text-base font-semibold text-white">{titleize(servo.name)}</p>
-                    </div>
-                    <p className="mt-2 text-xs uppercase tracking-[0.24em] text-slate-500">{servo.motion_phase}</p>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <MetricPill label="Angle" value={`${servo.angle.toFixed(1)}°`} icon={Gauge} />
-                    <MetricPill label="Target" value={`${servo.target_angle.toFixed(1)}°`} icon={Target} />
-                    <MetricPill label="Temp" value={`${servo.temperature_c.toFixed(1)}°C`} icon={Thermometer} />
-                  </div>
-                </div>
-
-                <div className="mt-4 grid gap-3 sm:grid-cols-[minmax(0,1fr)_120px] sm:items-center">
-                  <div>
-                    <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-[0.24em] text-slate-500">
-                      <span>Load</span>
-                      <span>{servo.load_pct.toFixed(1)}%</span>
-                    </div>
-                    <Progress value={servo.load_pct} className="h-2.5 bg-white/5" />
-                  </div>
-                  <div className="flex justify-start sm:justify-end">
-                    <Badge
-                      className={
-                        servo.torque_enabled
-                          ? "border-emerald-400/25 bg-emerald-400/10 text-emerald-200"
-                          : "border-slate-300/15 bg-slate-400/10 text-slate-200"
-                      }
-                    >
-                      {servo.torque_enabled ? "Torque On" : "Torque Off"}
-                    </Badge>
-                  </div>
-                </div>
+            {arms.some((arm) => arm.telemetry_live && arm.telemetry.length > 0) ? (
+              arms
+                .filter((arm) => arm.telemetry_live && arm.telemetry.length > 0)
+                .map((arm) => (
+                  <TelemetryGroup key={arm.arm_id} arm={arm} />
+                ))
+            ) : (
+              <div className="rounded-[22px] border border-dashed border-white/10 bg-black/20 p-6 text-sm text-slate-400">
+                Open a live connection on one of the verified arms to stream real joint positions, load, and
+                temperature from the SO-101 bus.
               </div>
-            ))}
+            )}
           </CardContent>
         </Card>
 
@@ -180,6 +150,7 @@ export function HardwareStatusDashboard({
                         <Badge>{titleize(arm.arm_type)}</Badge>
                         <Badge variant="muted">{titleize(arm.channel)} Channel</Badge>
                         <Badge className={tone.badgeClass}>{titleize(arm.verification.status)}</Badge>
+                        <Badge variant="muted">{arm.connected ? "Telemetry Connected" : "Telemetry Offline"}</Badge>
                       </div>
                       <CardTitle className="mt-4 text-2xl text-white">{arm.arm_id}</CardTitle>
                       <CardDescription className="text-slate-300">
@@ -215,6 +186,15 @@ export function HardwareStatusDashboard({
                             label="Joint Coverage"
                             value={`${arm.verification.detected_joint_count}/${arm.verification.expected_joint_count}`}
                           />
+                          <DashboardField
+                            label="Telemetry"
+                            value={
+                              arm.telemetry_live
+                                ? `Live${arm.telemetry_updated_at ? ` • ${new Date(arm.telemetry_updated_at).toLocaleTimeString()}` : ""}`
+                                : arm.telemetry_error ?? "Offline"
+                            }
+                            wrap
+                          />
                         </div>
                       </div>
                     </div>
@@ -235,7 +215,7 @@ export function HardwareStatusDashboard({
                     </div>
                     <div className="divide-y divide-white/10 bg-black/20">
                       {arm.joints.map((joint) => {
-                        const runtime = liveServoState.get(joint.servo_id);
+                        const runtime = servoRuntimeMap(arm.telemetry).get(joint.servo_id);
                         return (
                           <div
                             key={`${arm.arm_id}-${joint.joint_name}`}
@@ -269,6 +249,71 @@ export function HardwareStatusDashboard({
         </div>
       </div>
     </section>
+  );
+}
+
+function TelemetryGroup({ arm }: { arm: ArmAdapterState }) {
+  return (
+    <div className="rounded-[22px] border border-white/10 bg-black/20 p-4">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-3">
+            <Badge>{titleize(arm.arm_type)}</Badge>
+            <Badge variant="muted">{arm.arm_id}</Badge>
+          </div>
+          <p className="mt-2 text-sm text-slate-400">
+            {arm.telemetry_updated_at
+              ? `Last telemetry ${new Date(arm.telemetry_updated_at).toLocaleTimeString()}`
+              : "Telemetry stream active"}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-3">
+        {arm.telemetry.map((servo) => (
+          <div
+            key={`${arm.arm_id}-${servo.id}`}
+            className="rounded-[22px] border border-white/10 bg-black/25 p-4 shadow-[0_12px_34px_rgba(2,8,23,0.24)]"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-3">
+                  <Badge variant="muted">Servo {servo.id}</Badge>
+                  <p className="text-base font-semibold text-white">{titleize(servo.name)}</p>
+                </div>
+                <p className="mt-2 text-xs uppercase tracking-[0.24em] text-slate-500">{servo.motion_phase}</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <MetricPill label="Angle" value={`${servo.angle.toFixed(1)}°`} icon={Gauge} />
+                <MetricPill label="Target" value={`${servo.target_angle.toFixed(1)}°`} icon={Target} />
+                <MetricPill label="Temp" value={`${servo.temperature_c.toFixed(1)}°C`} icon={Thermometer} />
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-3 sm:grid-cols-[minmax(0,1fr)_120px] sm:items-center">
+              <div>
+                <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-[0.24em] text-slate-500">
+                  <span>Load</span>
+                  <span>{servo.load_pct.toFixed(1)}%</span>
+                </div>
+                <Progress value={servo.load_pct} className="h-2.5 bg-white/5" />
+              </div>
+              <div className="flex justify-start sm:justify-end">
+                <Badge
+                  className={
+                    servo.torque_enabled
+                      ? "border-emerald-400/25 bg-emerald-400/10 text-emerald-200"
+                      : "border-slate-300/15 bg-slate-400/10 text-slate-200"
+                  }
+                >
+                  {servo.torque_enabled ? "Torque On" : "Torque Off"}
+                </Badge>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -215,6 +215,10 @@ export interface ArmAdapterState {
   safety: ArmSafetyEnvelope;
   joints: ArmJointConfig[];
   verification: ArmVerificationState;
+  telemetry_live: boolean;
+  telemetry_updated_at?: string | null;
+  telemetry_error?: string | null;
+  telemetry: ServoState[];
   preview: ArmPreviewState;
   notes?: string | null;
 }


### PR DESCRIPTION
Closes #31

## Summary
- add a real read-only LeRobot/Feetech hardware bridge for the SO-101 leader and follower arms
- separate verification-ready state from an active live telemetry session and expose per-arm joint telemetry in the API
- update the robot dashboard to show real arm telemetry once a live connection is opened

## Verification
- python3 -m compileall backend/app
- backend/.venv/bin/python -m unittest discover -s backend/tests -v
- npm run build
- safe local telemetry probe against configured ports via TestClient: both leader and follower connected, exposed 6 live joints each, then disconnected cleanly
