### PR TITLE
feat: enforce live arm safety supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,11 @@ The backend now exposes a dry-run dual-arm execution surface for your SO-101 lea
 - `POST /api/arms/{arm_id}/connect` now opens a real read-only telemetry session for the selected arm
 - `POST /api/arms/execution-mode` switches between `mirror`, `unison`, `call_response`, and `asymmetric`
 - `POST /api/arms/{arm_id}/safety` updates per-arm dry-run/safety settings plus joint overrides for offsets, inversion, limits, and speed caps
-- `POST /api/arms/emergency-stop` disables torque in the adapter layer before any real motor writes are attempted
-- `POST /api/arms/neutral` moves the planning state back to the neutral scene
+- `POST /api/arms/emergency-stop` holds the current live pose and disables torque immediately on connected arms
+- `POST /api/arms/emergency-reset` clears emergency-stop state so torque can be re-enabled explicitly
+- `POST /api/arms/neutral` moves connected arms toward the neutral pose through the same live step-limited safety envelope used for future motion writes
 
-This is still a planning and validation layer for motion writes. It does not send choreography to real hardware yet, but it now opens real SO-101 read-only telemetry sessions and reports live joint values for each arm.
+This is still a planning and validation layer for choreography writes. It now opens real SO-101 telemetry sessions, exposes live safety controls, and can issue bounded neutral/safety commands without starting dance playback.
 
 Install or refresh backend dependencies after pulling:
 

--- a/backend/app/arms.py
+++ b/backend/app/arms.py
@@ -6,6 +6,7 @@ import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from time import sleep
 from typing import Any, Protocol
 
 try:
@@ -47,8 +48,20 @@ DEFAULT_JOINT_LAYOUT = [
     (6, "gripper"),
 ]
 
+NEUTRAL_JOINT_TARGETS = {
+    "shoulder_pan": 0.0,
+    "shoulder_lift": -12.0,
+    "elbow_flex": 18.0,
+    "wrist_flex": 0.0,
+    "wrist_roll": 0.0,
+    "gripper": 8.0,
+}
+
 ROOT_DIR = Path(__file__).resolve().parents[2]
 DEFAULT_EXPECTED_JOINT_COUNT = len(DEFAULT_JOINT_LAYOUT)
+HEARTBEAT_TIMEOUT_SECONDS = 1.5
+NEUTRAL_TOLERANCE_DEGREES = 2.0
+MAX_NEUTRAL_COMMAND_STEPS = 18
 
 
 @dataclass
@@ -72,6 +85,12 @@ class ArmRuntime:
     verification: ArmVerificationState
     telemetry: ArmTelemetryRuntime = field(default_factory=ArmTelemetryRuntime)
     joints: list[ArmJointConfig] = field(default_factory=list)
+    last_command_at: str | None = None
+    last_command_error: str | None = None
+
+
+def clamp(value: float, lower: float, upper: float) -> float:
+    return min(upper, max(lower, value))
 
 
 class LeRobotArmVerifier:
@@ -259,6 +278,10 @@ class ArmHardwareBridge(Protocol):
 
     def read_telemetry(self, arm: ArmRuntime) -> list[ServoState]: ...
 
+    def set_torque_enabled(self, arm: ArmRuntime, enabled: bool) -> None: ...
+
+    def write_joint_targets(self, arm: ArmRuntime, targets: dict[str, float]) -> None: ...
+
 
 @dataclass
 class LeRobotBusSession:
@@ -314,6 +337,24 @@ class LeRobotHardwareBridge:
             for servo_id, joint_name in DEFAULT_JOINT_LAYOUT
         ]
 
+    def set_torque_enabled(self, arm: ArmRuntime, enabled: bool) -> None:
+        session = self.sessions.get(arm.arm_id)
+        if session is None:
+            raise RuntimeError(f"Arm '{arm.arm_id}' is not connected for safety control")
+
+        session.bus.sync_write(
+            "Torque_Enable",
+            {joint_name: 1 if enabled else 0 for _, joint_name in DEFAULT_JOINT_LAYOUT},
+            normalize=False,
+        )
+
+    def write_joint_targets(self, arm: ArmRuntime, targets: dict[str, float]) -> None:
+        session = self.sessions.get(arm.arm_id)
+        if session is None:
+            raise RuntimeError(f"Arm '{arm.arm_id}' is not connected for command writes")
+
+        session.bus.sync_write("Goal_Position", targets, normalize=True)
+
     def _build_session(self, arm: ArmRuntime) -> LeRobotBusSession:
         if not arm.port:
             raise RuntimeError(f"Arm '{arm.arm_id}' has no configured serial port")
@@ -360,6 +401,7 @@ class DualArmAdapter:
         self.execution_mode = ExecutionMode.MIRROR
         self.neutral_pose_scene = SceneName.IDLE
         self.required_dry_run = True
+        self.last_command_at: str | None = None
         self.arms: dict[str, ArmRuntime] = {}
         self.verifier = verifier or LeRobotArmVerifier()
         self.bridge = bridge or LeRobotHardwareBridge()
@@ -444,6 +486,8 @@ class DualArmAdapter:
                 self.bridge.connect(arm)
                 arm.connected = self.bridge.is_connected(arm)
                 self.refresh_telemetry(arm_id)
+                self.bridge.set_torque_enabled(arm, arm.safety.torque_enabled and not arm.safety.emergency_stop)
+                self.refresh_telemetry(arm_id)
                 arm.notes = f"{arm.arm_id} is streaming live telemetry."
             except Exception as exc:
                 arm.connected = False
@@ -482,14 +526,44 @@ class DualArmAdapter:
 
         if arm.safety.emergency_stop:
             arm.safety.torque_enabled = False
+            if self.bridge.is_connected(arm):
+                self._apply_emergency_stop_to_arm(arm)
+            arm.notes = "Emergency stop engaged. Live writes are disabled."
+            return
+
+        if self.bridge.is_connected(arm) and (payload.torque_enabled is not None or payload.emergency_stop is not None):
+            self.bridge.set_torque_enabled(arm, arm.safety.torque_enabled)
+            self.refresh_telemetry(arm_id)
+
+        arm.notes = (
+            f"Safety updated. Torque {'enabled' if arm.safety.torque_enabled else 'disabled'}; "
+            f"dry run {'on' if arm.safety.dry_run else 'off'}."
+        )
 
     def emergency_stop(self) -> None:
         for arm in self.arms.values():
             arm.safety.emergency_stop = True
             arm.safety.torque_enabled = False
+            if self.bridge.is_connected(arm):
+                self._apply_emergency_stop_to_arm(arm)
+            arm.notes = "Emergency stop engaged. Live writes are disabled."
+
+    def reset_emergency_stop(self) -> None:
+        for arm in self.arms.values():
+            arm.safety.emergency_stop = False
+            if self.bridge.is_connected(arm):
+                self.bridge.set_torque_enabled(arm, arm.safety.torque_enabled)
+                self.refresh_telemetry(arm.arm_id)
+            arm.notes = "Emergency stop cleared. Re-enable torque before live motion."
 
     def neutralize(self) -> None:
         self.neutral_pose_scene = SceneName.IDLE
+        for arm in self.arms.values():
+            if not self.bridge.is_connected(arm):
+                continue
+            applied = self._write_safe_targets(arm, NEUTRAL_JOINT_TARGETS, reason="Neutral pose")
+            if applied:
+                arm.notes = "Moved toward neutral pose within live safety limits."
 
     def verify_all(self) -> None:
         for arm_id in self.arms:
@@ -575,7 +649,7 @@ class DualArmAdapter:
             execution=DualArmExecutionState(
                 mode=self.execution_mode,
                 choreography_ready=choreography_ready,
-                dry_run_required=self.required_dry_run,
+                dry_run_required=self._dry_run_required(),
                 emergency_stop_active=self.emergency_stop_active(),
                 neutral_pose_scene=self.neutral_pose_scene,
             ),
@@ -624,6 +698,115 @@ class DualArmAdapter:
             joint.max_angle = override.max_angle
         if override.max_speed is not None:
             joint.max_speed = override.max_speed
+
+    def _dry_run_required(self) -> bool:
+        connected = [arm for arm in self.arms.values() if arm.connected]
+        if not connected:
+            return True
+        return any(arm.safety.dry_run for arm in connected)
+
+    def _apply_emergency_stop_to_arm(self, arm: ArmRuntime) -> None:
+        try:
+            current = self.refresh_telemetry(arm.arm_id)
+            if current:
+                self.bridge.write_joint_targets(arm, {servo.name: servo.angle for servo in current})
+            self.bridge.set_torque_enabled(arm, False)
+            self.refresh_telemetry(arm.arm_id)
+            arm.last_command_at = datetime.now(UTC).isoformat()
+            arm.last_command_error = None
+        except Exception as exc:
+            arm.last_command_error = str(exc)
+            arm.notes = f"Emergency stop failed on {arm.arm_id}: {exc}"
+
+    def _write_safe_targets(
+        self,
+        arm: ArmRuntime,
+        targets: dict[str, float],
+        *,
+        reason: str,
+    ) -> bool:
+        if arm.safety.dry_run or arm.safety.emergency_stop or not arm.safety.torque_enabled:
+            return False
+        if not self.bridge.is_connected(arm):
+            return False
+
+        for _ in range(MAX_NEUTRAL_COMMAND_STEPS):
+            current_servos = self.refresh_telemetry(arm.arm_id)
+            if not current_servos:
+                return False
+            if not self._telemetry_is_fresh(arm):
+                arm.last_command_error = f"{arm.arm_id} telemetry heartbeat is stale."
+                arm.notes = arm.last_command_error
+                return False
+            current_map = {servo.name: servo for servo in current_servos}
+            safe_targets = self._limit_joint_targets(arm, current_map, targets)
+            if not safe_targets:
+                return True
+
+            self.bridge.write_joint_targets(arm, safe_targets)
+            arm.last_command_at = datetime.now(UTC).isoformat()
+            arm.last_command_error = None
+            self.last_command_at = arm.last_command_at
+            sleep(0.03)
+
+            latest_servos = self.refresh_telemetry(arm.arm_id)
+            if self._targets_reached(arm, {servo.name: servo for servo in latest_servos}, targets):
+                return True
+
+        arm.notes = f"{reason} stopped at step limit. Run again if more settling is needed."
+        return True
+
+    def _limit_joint_targets(
+        self,
+        arm: ArmRuntime,
+        current: dict[str, ServoState],
+        targets: dict[str, float],
+    ) -> dict[str, float]:
+        safe_targets: dict[str, float] = {}
+        for joint in arm.joints:
+            if joint.joint_name not in targets:
+                continue
+
+            current_servo = current.get(joint.joint_name)
+            if current_servo is None:
+                continue
+
+            requested = targets[joint.joint_name]
+            desired = (-requested if joint.inverted else requested) + joint.offset_degrees
+            desired = clamp(desired, joint.min_angle, joint.max_angle)
+
+            max_step = max(1.0, arm.safety.max_step_degrees * joint.max_speed * arm.safety.speed_scale)
+            delta = clamp(desired - current_servo.angle, -max_step, max_step)
+            stepped = round(current_servo.angle + delta, 2)
+
+            if abs(desired - current_servo.angle) <= NEUTRAL_TOLERANCE_DEGREES:
+                continue
+
+            safe_targets[joint.joint_name] = stepped
+
+        return safe_targets
+
+    def _targets_reached(self, arm: ArmRuntime, current: dict[str, ServoState], targets: dict[str, float]) -> bool:
+        joint_map = {joint.joint_name: joint for joint in arm.joints}
+        for joint_name, requested in targets.items():
+            servo = current.get(joint_name)
+            if servo is None:
+                continue
+            joint = joint_map.get(joint_name)
+            desired = requested
+            if joint is not None:
+                desired = (-requested if joint.inverted else requested) + joint.offset_degrees
+                desired = clamp(desired, joint.min_angle, joint.max_angle)
+            if abs(servo.angle - desired) > NEUTRAL_TOLERANCE_DEGREES:
+                return False
+        return True
+
+    def _telemetry_is_fresh(self, arm: ArmRuntime) -> bool:
+        if not arm.telemetry.updated_at:
+            return False
+        updated_at = datetime.fromisoformat(arm.telemetry.updated_at)
+        age = (datetime.now(UTC) - updated_at).total_seconds()
+        return age <= HEARTBEAT_TIMEOUT_SECONDS
 
     def _arm(self, arm_id: str) -> ArmRuntime:
         arm = self.arms.get(arm_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -136,6 +136,11 @@ def emergency_stop() -> DualArmState:
     return store.emergency_stop()
 
 
+@app.post("/api/arms/emergency-reset", response_model=DualArmState)
+def emergency_reset() -> DualArmState:
+    return store.reset_emergency_stop()
+
+
 @app.post("/api/arms/neutral", response_model=DualArmState)
 def move_arms_to_neutral() -> DualArmState:
     return store.move_to_neutral()

--- a/backend/app/state.py
+++ b/backend/app/state.py
@@ -412,6 +412,11 @@ class RobotStateStore:
         self._sync_follower_torque_state()
         return self.arms_snapshot()
 
+    def reset_emergency_stop(self) -> DualArmState:
+        self.arm_adapter.reset_emergency_stop()
+        self._sync_follower_torque_state()
+        return self.arms_snapshot()
+
     def move_to_neutral(self) -> DualArmState:
         self.arm_adapter.neutralize()
         self.transport.playing = False

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -47,9 +47,22 @@ DEFAULT_SERVO_LAYOUT = [
 class FakeTelemetryBridge:
     def __init__(self) -> None:
         self.connected: set[str] = set()
+        self.torque_enabled: dict[str, bool] = {}
+        self.angles: dict[str, dict[str, float]] = {}
+        self.goals: dict[str, dict[str, float]] = {}
 
     def connect(self, arm: ArmRuntime) -> None:
         self.connected.add(arm.arm_id)
+        self.torque_enabled.setdefault(arm.arm_id, True)
+        base = 10.0 if arm.arm_type == "leader" else 20.0
+        self.angles.setdefault(
+            arm.arm_id,
+            {name: base + servo_id for servo_id, name in DEFAULT_SERVO_LAYOUT},
+        )
+        self.goals.setdefault(
+            arm.arm_id,
+            {name: base + servo_id + 0.5 for servo_id, name in DEFAULT_SERVO_LAYOUT},
+        )
 
     def disconnect(self, arm: ArmRuntime) -> None:
         self.connected.discard(arm.arm_id)
@@ -58,14 +71,15 @@ class FakeTelemetryBridge:
         return arm.arm_id in self.connected
 
     def read_telemetry(self, arm: ArmRuntime) -> list[ServoState]:
-        base = 10.0 if arm.arm_type == "leader" else 20.0
-        torque_enabled = arm.safety.torque_enabled and not arm.safety.emergency_stop
+        torque_enabled = self.torque_enabled.get(arm.arm_id, arm.safety.torque_enabled and not arm.safety.emergency_stop)
+        angles = self.angles.get(arm.arm_id, {})
+        goals = self.goals.get(arm.arm_id, angles)
         return [
             ServoState(
                 id=servo_id,
                 name=name,
-                angle=base + servo_id,
-                target_angle=base + servo_id + 0.5,
+                angle=angles.get(name, 0.0),
+                target_angle=goals.get(name, angles.get(name, 0.0)),
                 torque_enabled=torque_enabled,
                 temperature_c=32.0 + servo_id,
                 load_pct=10.0 + servo_id,
@@ -73,6 +87,16 @@ class FakeTelemetryBridge:
             )
             for servo_id, name in DEFAULT_SERVO_LAYOUT
         ]
+
+    def set_torque_enabled(self, arm: ArmRuntime, enabled: bool) -> None:
+        self.torque_enabled[arm.arm_id] = enabled
+
+    def write_joint_targets(self, arm: ArmRuntime, targets: dict[str, float]) -> None:
+        self.goals.setdefault(arm.arm_id, {}).update(targets)
+        angles = self.angles.setdefault(arm.arm_id, {})
+        for joint_name, target in targets.items():
+            current = angles.get(joint_name, target)
+            angles[joint_name] = current + (target - current) * 0.8
 
 
 class ApiSmokeTest(unittest.TestCase):
@@ -213,6 +237,8 @@ class ApiSmokeTest(unittest.TestCase):
         safety_update = self.client.post(
             "/api/arms/test_leader/safety",
             json={
+                "dry_run": False,
+                "torque_enabled": False,
                 "amplitude_scale": 0.74,
                 "speed_scale": 0.8,
                 "joint_overrides": [
@@ -228,10 +254,21 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertEqual(safety_update.status_code, 200)
         leader = next(arm for arm in safety_update.json()["arms"] if arm["arm_id"] == "test_leader")
         self.assertAlmostEqual(leader["safety"]["amplitude_scale"], 0.74, places=2)
+        self.assertFalse(leader["safety"]["dry_run"])
+        self.assertFalse(leader["safety"]["torque_enabled"])
         wrist_roll = next(joint for joint in leader["joints"] if joint["joint_name"] == "wrist_roll")
         self.assertFalse(wrist_roll["inverted"])
         self.assertAlmostEqual(wrist_roll["offset_degrees"], 7.5, places=2)
         self.assertAlmostEqual(wrist_roll["max_speed"], 0.7, places=2)
+
+        reenable = self.client.post(
+            "/api/arms/test_leader/safety",
+            json={"torque_enabled": True},
+        )
+        self.assertEqual(reenable.status_code, 200)
+        leader_live_again = next(arm for arm in reenable.json()["arms"] if arm["arm_id"] == "test_leader")
+        self.assertTrue(leader_live_again["safety"]["torque_enabled"])
+        self.assertTrue(all(servo["torque_enabled"] for servo in leader_live_again["telemetry"]))
 
         emergency_stop = self.client.post("/api/arms/emergency-stop")
         self.assertEqual(emergency_stop.status_code, 200)
@@ -244,9 +281,24 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertFalse(state_after_stop.json()["transport"]["playing"])
         self.assertTrue(all(not servo["torque_enabled"] for servo in state_after_stop.json()["servos"]))
 
+        reset = self.client.post("/api/arms/emergency-reset")
+        self.assertEqual(reset.status_code, 200)
+        self.assertFalse(reset.json()["execution"]["emergency_stop_active"])
+
+        follower_reenable = self.client.post(
+            "/api/arms/test_follower/safety",
+            json={"torque_enabled": True, "dry_run": False},
+        )
+        self.assertEqual(follower_reenable.status_code, 200)
+
         neutral = self.client.post("/api/arms/neutral")
         self.assertEqual(neutral.status_code, 200)
         self.assertEqual(neutral.json()["execution"]["neutral_pose_scene"], "idle")
+        follower_neutral = next(arm for arm in neutral.json()["arms"] if arm["arm_id"] == "test_follower")
+        follower_goals = {servo["name"]: servo["target_angle"] for servo in follower_neutral["telemetry"]}
+        self.assertAlmostEqual(follower_goals["shoulder_pan"], 0.0, places=1)
+        self.assertAlmostEqual(follower_goals["shoulder_lift"], -12.0, places=1)
+        self.assertAlmostEqual(follower_goals["elbow_flex"], 18.0, places=1)
 
         cache_files = list((Path(self.tempdir.name) / "analysis-cache" / "json" / "local").glob("*.json"))
         self.assertTrue(cache_files)

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -135,12 +135,20 @@ These contracts started ahead of the implementation. The real backend analysis p
 }
 ```
 - Response: `DualArmState`
+- When the arm is connected, torque changes are applied to the live Feetech bus immediately
+- Live target writes remain blocked while `dry_run=true`
 
 ### `POST /api/arms/emergency-stop`
 - Response: `DualArmState`
+- Immediately disables live torque on every connected arm and blocks further live writes
+
+### `POST /api/arms/emergency-reset`
+- Response: `DualArmState`
+- Clears the emergency-stop latch so torque can be re-enabled arm by arm
 
 ### `POST /api/arms/neutral`
 - Response: `DualArmState`
+- When a connected arm is live-enabled, the backend steps it toward the neutral scene through the same joint limits and max-step guard used by the live write path
 
 ## Canonical Models
 

--- a/docs/IMPLEMENTATION_TRACKER.md
+++ b/docs/IMPLEMENTATION_TRACKER.md
@@ -23,15 +23,15 @@ The delivery sequence is:
 - `#19` Add GitHub Actions CI for backend, frontend, and smoke validation
 - `#20` Dockerize frontend and backend with docker compose startup
 - `#29` Verify live SO-101 connection and calibration loading for both arms [done]
-- `#31` Implement real dual-arm SO-101 hardware bridge and telemetry
+- `#31` Implement real dual-arm SO-101 hardware bridge and telemetry [done]
 - `#30` Enforce live safety supervisor for torque, neutral, emergency stop, and step limits
 - `#32` Add manual hardware validation controls and status surfaces [done]
-- `#38` Add live 2D dual-arm visualizer to robot dashboard
+- `#38` Add live 2D dual-arm visualizer to robot dashboard [done]
 - `#34` Execute choreography on one live SO-101 arm
 - `#33` Run synchronized dual-arm choreography playback on leader + follower
 
 ## Current Status
-- Current PR target: `#38`
+- Current PR target: `#30`
 - Current backend state:
   - Search and track selection exist
   - Local upload and persistent local track metadata are available
@@ -44,6 +44,7 @@ The delivery sequence is:
   - `#31` now opens real read-only LeRobot/Feetech sessions for leader + follower and exposes live joint telemetry in `/api/state` and `/api/arms`
   - Active bus sessions are now distinct from verification-ready state; `connected=true` means a live telemetry session is open
   - The backend now requires `feetech-servo-sdk` for real SO-101 telemetry through LeRobot
+  - `#30` is wiring torque on/off, neutral moves, emergency stop, emergency reset, and live joint step limiting through the real Feetech write path
 - Current frontend state:
   - Home page is music-first
   - Search/select flow exists
@@ -52,8 +53,9 @@ The delivery sequence is:
   - Spectrogram, rhythm, structure, and track-info tabs are wired to the real backend analysis payload
   - Hardware dashboard now separates verification-ready state from active telemetry state
   - Robot dashboard now shows real per-arm telemetry once a live connection is opened
-  - `#38` is adding a responsive side-by-side 2D visualizer so both arms can be seen moving from live telemetry
-  - Live hardware execution is not implemented yet; the current dual-arm adapter remains read-only/dry-run for writes
+  - `#38` added a responsive side-by-side 2D visualizer so both arms can be seen moving from live telemetry
+  - `#30` is wiring dashboard controls for dry-run, torque, neutral, and emergency-stop management
+  - Live choreography execution is not implemented yet, but the adapter can now issue bounded safety writes for torque, neutral, and emergency-stop handling
 
 ## Workflow Rule
 - Each ticket must ship from a feature branch through a pull request.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,11 +6,15 @@ import {
   fetchAnalysisStatus,
   fetchChoreography,
   fetchState,
+  moveArmsToNeutral,
+  resetEmergencyStop,
   searchTracks,
   setArmConnection,
   selectTrack,
   setTransport,
   startAnalysis,
+  triggerEmergencyStop,
+  updateArmSafety,
   uploadTrack,
   verifyArms,
 } from "@/lib/api";
@@ -57,6 +61,7 @@ function App() {
   const [previewPlaying, setPreviewPlaying] = useState(false);
   const [verifyingHardware, setVerifyingHardware] = useState(false);
   const [hardwareBusyArmId, setHardwareBusyArmId] = useState<string | null>(null);
+  const [hardwareActionBusy, setHardwareActionBusy] = useState<string | null>(null);
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
 
   const refreshState = async () => {
@@ -308,6 +313,53 @@ function App() {
     }
   }, []);
 
+  const handleUpdateArmSafety = useCallback(
+    async (
+      armId: string,
+      payload: {
+        dry_run?: boolean;
+        emergency_stop?: boolean;
+        torque_enabled?: boolean;
+      },
+      busyKey: string,
+    ) => {
+      setHardwareActionBusy(busyKey);
+      try {
+        await updateArmSafety(armId, payload);
+        await refreshState();
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unable to update arm safety");
+      } finally {
+        setHardwareActionBusy(null);
+      }
+    },
+    [],
+  );
+
+  const handleGlobalArmAction = useCallback(
+    async (action: "neutral" | "emergency-stop" | "emergency-reset") => {
+      setHardwareActionBusy(action);
+      try {
+        if (action === "neutral") {
+          await moveArmsToNeutral();
+        } else if (action === "emergency-stop") {
+          await triggerEmergencyStop();
+        } else {
+          await resetEmergencyStop();
+        }
+        await refreshState();
+        setError(null);
+        setActiveView("robot");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unable to update arm safety");
+      } finally {
+        setHardwareActionBusy(null);
+      }
+    },
+    [],
+  );
+
   const searchDropdownResults = useMemo(() => {
     const deduped = new Map<string, TrackSummary>();
     [...localTracks, ...searchResults].forEach((track) => {
@@ -502,8 +554,21 @@ function App() {
             loading={loading}
             verifying={verifyingHardware}
             busyArmId={hardwareBusyArmId}
+            busyAction={hardwareActionBusy}
             onVerify={() => void handleVerifyHardware()}
             onToggleConnection={(armId, connected) => void handleToggleArmConnection(armId, connected)}
+            onToggleDryRun={(armId, dryRun) =>
+              void handleUpdateArmSafety(armId, { dry_run: dryRun }, `${armId}:dry-run`)
+            }
+            onToggleTorque={(armId, enabled) =>
+              void handleUpdateArmSafety(armId, { torque_enabled: enabled }, `${armId}:torque`)
+            }
+            onResetArmEmergencyStop={(armId) =>
+              void handleUpdateArmSafety(armId, { emergency_stop: false }, `${armId}:reset-estop`)
+            }
+            onNeutralAll={() => void handleGlobalArmAction("neutral")}
+            onEmergencyStop={() => void handleGlobalArmAction("emergency-stop")}
+            onEmergencyReset={() => void handleGlobalArmAction("emergency-reset")}
           />
         ) : null}
 

--- a/frontend/src/components/hardware/hardware-status-dashboard.tsx
+++ b/frontend/src/components/hardware/hardware-status-dashboard.tsx
@@ -61,15 +61,29 @@ export function HardwareStatusDashboard({
   loading,
   verifying,
   busyArmId,
+  busyAction,
   onVerify,
   onToggleConnection,
+  onToggleDryRun,
+  onToggleTorque,
+  onResetArmEmergencyStop,
+  onNeutralAll,
+  onEmergencyStop,
+  onEmergencyReset,
 }: {
   state: RobotState | null;
   loading: boolean;
   verifying: boolean;
   busyArmId: string | null;
+  busyAction: string | null;
   onVerify: () => void;
   onToggleConnection: (armId: string, connected: boolean) => void;
+  onToggleDryRun: (armId: string, dryRun: boolean) => void;
+  onToggleTorque: (armId: string, enabled: boolean) => void;
+  onResetArmEmergencyStop: (armId: string) => void;
+  onNeutralAll: () => void;
+  onEmergencyStop: () => void;
+  onEmergencyReset: () => void;
 }) {
   const arms = state?.dual_arm.arms ?? [];
   const execution = state?.dual_arm.execution;
@@ -100,6 +114,24 @@ export function HardwareStatusDashboard({
             <Button variant="secondary" onClick={onVerify} disabled={verifying}>
               <RefreshCw className={`mr-2 h-4 w-4 ${verifying ? "animate-spin" : ""}`} />
               {verifying ? "Checking Hardware..." : "Run Verification"}
+            </Button>
+            <Button variant="ghost" onClick={onNeutralAll} disabled={busyAction !== null}>
+              {busyAction === "neutral" ? "Moving..." : "Neutral All"}
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={onEmergencyReset}
+              disabled={busyAction !== null || !execution?.emergency_stop_active}
+            >
+              {busyAction === "emergency-reset" ? "Resetting..." : "Reset E-Stop"}
+            </Button>
+            <Button
+              variant="secondary"
+              className="border border-red-300/20 bg-red-500/10 text-red-100 hover:bg-red-500/20"
+              onClick={onEmergencyStop}
+              disabled={busyAction !== null}
+            >
+              {busyAction === "emergency-stop" ? "Stopping..." : "Emergency Stop"}
             </Button>
           </div>
         </CardHeader>
@@ -207,6 +239,38 @@ export function HardwareStatusDashboard({
                     <StatusBlock label="Amplitude" value={arm.safety.amplitude_scale.toFixed(2)} />
                     <StatusBlock label="Speed" value={arm.safety.speed_scale.toFixed(2)} />
                     <StatusBlock label="Step Limit" value={`${arm.safety.max_step_degrees.toFixed(1)}°`} />
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <Button
+                      variant={arm.safety.dry_run ? "secondary" : "ghost"}
+                      disabled={busyAction !== null}
+                      onClick={() => onToggleDryRun(arm.arm_id, !arm.safety.dry_run)}
+                    >
+                      {busyAction === `${arm.arm_id}:dry-run`
+                        ? "Updating..."
+                        : arm.safety.dry_run
+                          ? "Dry Run On"
+                          : "Dry Run Off"}
+                    </Button>
+                    <Button
+                      variant={arm.safety.torque_enabled ? "secondary" : "ghost"}
+                      disabled={busyAction !== null || arm.safety.emergency_stop}
+                      onClick={() => onToggleTorque(arm.arm_id, !arm.safety.torque_enabled)}
+                    >
+                      {busyAction === `${arm.arm_id}:torque`
+                        ? "Updating..."
+                        : arm.safety.torque_enabled
+                          ? "Torque On"
+                          : "Torque Off"}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      disabled={busyAction !== null || !arm.safety.emergency_stop}
+                      onClick={() => onResetArmEmergencyStop(arm.arm_id)}
+                    >
+                      {busyAction === `${arm.arm_id}:reset-estop` ? "Resetting..." : "Clear Arm E-Stop"}
+                    </Button>
                   </div>
 
                   <div className="overflow-hidden rounded-[22px] border border-white/10">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -54,6 +54,42 @@ export function setArmConnection(armId: string, connected: boolean) {
   });
 }
 
+export function updateArmSafety(
+  armId: string,
+  payload: {
+    dry_run?: boolean;
+    emergency_stop?: boolean;
+    neutral_on_stop?: boolean;
+    torque_enabled?: boolean;
+    amplitude_scale?: number;
+    speed_scale?: number;
+    max_step_degrees?: number;
+  },
+) {
+  return request<DualArmState>(`/api/arms/${armId}/safety`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function triggerEmergencyStop() {
+  return request<DualArmState>("/api/arms/emergency-stop", {
+    method: "POST",
+  });
+}
+
+export function resetEmergencyStop() {
+  return request<DualArmState>("/api/arms/emergency-reset", {
+    method: "POST",
+  });
+}
+
+export function moveArmsToNeutral() {
+  return request<DualArmState>("/api/arms/neutral", {
+    method: "POST",
+  });
+}
+
 export function setMode(mode: DanceMode) {
   return request<RobotState>("/api/mode", {
     method: "POST",


### PR DESCRIPTION
Closes #30

## Summary
- enforce live torque, emergency-stop, emergency-reset, and neutral commands through the real arm safety path
- apply bounded step-limited neutral moves and telemetry freshness guards before live writes
- add dashboard safety controls and smoke-test coverage for the new live supervisor behavior

## Verification
- python3 -m compileall backend/app
- backend/.venv/bin/python -m unittest discover -s backend/tests -v
- npm run build