### PR TITLE
fix: harden per-arm reset recovery

### DIFF
--- a/backend/app/arms.py
+++ b/backend/app/arms.py
@@ -644,6 +644,42 @@ class DualArmAdapter:
         for arm_id in self.arms:
             self.verify_arm(arm_id)
 
+    def reset_arm_state(self, arm_id: str) -> None:
+        arm = self._arm(arm_id)
+        was_connected = self.bridge.is_connected(arm)
+
+        if self._movement_state.status == MovementStatus.RUNNING and self._movement_state.arm_id == arm_id:
+            self.stop_movement()
+
+        if was_connected:
+            with self._command_lock:
+                self.bridge.disconnect(arm)
+
+        arm.safety = self._default_safety(arm.arm_type)
+        arm.joints = self._default_joints(arm.arm_type)
+        arm.connected = False
+        arm.telemetry.live = False
+        arm.telemetry.error = None
+        arm.telemetry.updated_at = None
+        arm.telemetry.servos = []
+        arm.last_command_at = None
+        arm.last_command_error = None
+        arm.notes = self._default_note(arm.arm_type)
+
+        verification = self.verify_arm(arm_id)
+        if verification.status != ArmVerificationStatus.READY:
+            arm.notes = verification.message or f"{arm_id} reset, but verification is not ready."
+            return
+
+        if was_connected:
+            with self._command_lock:
+                self.bridge.connect(arm)
+                arm.connected = self.bridge.is_connected(arm)
+                self.refresh_telemetry(arm_id)
+                self.bridge.set_torque_enabled(arm, True)
+                self.refresh_telemetry(arm_id)
+            arm.notes = f"{arm.arm_id} reset to default live state."
+
     def verify_arm(self, arm_id: str) -> ArmVerificationState:
         arm = self._arm(arm_id)
         verification = self.verifier.verify(arm)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -133,6 +133,14 @@ def update_arm_safety(arm_id: str, payload: ArmSafetyUpdate) -> DualArmState:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+@app.post("/api/arms/{arm_id}/reset-state", response_model=DualArmState)
+def reset_arm_state(arm_id: str) -> DualArmState:
+    try:
+        return store.reset_arm_state(arm_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 @app.post("/api/arms/emergency-stop", response_model=DualArmState)
 def emergency_stop() -> DualArmState:
     return store.emergency_stop()

--- a/backend/app/state.py
+++ b/backend/app/state.py
@@ -407,6 +407,11 @@ class RobotStateStore:
         self._sync_follower_torque_state()
         return self.arms_snapshot()
 
+    def reset_arm_state(self, arm_id: str) -> DualArmState:
+        self.arm_adapter.reset_arm_state(arm_id)
+        self._sync_follower_torque_state()
+        return self.arms_snapshot()
+
     def emergency_stop(self) -> DualArmState:
         self.arm_adapter.emergency_stop()
         self.transport.playing = False

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -293,6 +293,35 @@ class ApiSmokeTest(unittest.TestCase):
         )
         self.assertEqual(follower_reenable.status_code, 200)
 
+        mutated = self.client.post(
+            "/api/arms/test_follower/safety",
+            json={
+                "dry_run": False,
+                "torque_enabled": False,
+                "amplitude_scale": 1.45,
+                "joint_overrides": [{"joint_name": "shoulder_pan", "offset_degrees": 11.0}],
+            },
+        )
+        self.assertEqual(mutated.status_code, 200)
+
+        reset_arm = self.client.post("/api/arms/test_follower/reset-state")
+        self.assertEqual(reset_arm.status_code, 200)
+        reset_follower = next(arm for arm in reset_arm.json()["arms"] if arm["arm_id"] == "test_follower")
+        self.assertTrue(reset_follower["connected"])
+        self.assertTrue(reset_follower["telemetry_live"])
+        self.assertTrue(reset_follower["safety"]["dry_run"])
+        self.assertTrue(reset_follower["safety"]["torque_enabled"])
+        self.assertAlmostEqual(reset_follower["safety"]["amplitude_scale"], 1.0, places=2)
+        reset_joint = next(joint for joint in reset_follower["joints"] if joint["joint_name"] == "shoulder_pan")
+        self.assertAlmostEqual(reset_joint["offset_degrees"], 0.0, places=2)
+        self.assertTrue(all(servo["torque_enabled"] for servo in reset_follower["telemetry"]))
+
+        follower_live_after_reset = self.client.post(
+            "/api/arms/test_follower/safety",
+            json={"torque_enabled": True, "dry_run": False},
+        )
+        self.assertEqual(follower_live_after_reset.status_code, 200)
+
         neutral = self.client.post("/api/arms/neutral")
         self.assertEqual(neutral.status_code, 200)
         self.assertEqual(neutral.json()["execution"]["neutral_pose_scene"], "idle")
@@ -320,7 +349,7 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertEqual(run_wave.json()["active"]["preset_id"], "normal")
 
         completed = None
-        for _ in range(140):
+        for _ in range(240):
             snapshot = self.client.get("/api/movements")
             self.assertEqual(snapshot.status_code, 200)
             active = snapshot.json()["active"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import {
   fetchMovementLibrary,
   fetchState,
   moveArmsToNeutral,
+  resetArmState,
   runMovement,
   resetEmergencyStop,
   searchTracks,
@@ -364,6 +365,19 @@ function App() {
     [],
   );
 
+  const handleResetArmState = useCallback(async (armId: string) => {
+    setHardwareActionBusy(`${armId}:reset-state`);
+    try {
+      await resetArmState(armId);
+      await refreshState();
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to reset arm state");
+    } finally {
+      setHardwareActionBusy(null);
+    }
+  }, []);
+
   const handleGlobalArmAction = useCallback(
     async (action: "neutral" | "emergency-stop" | "emergency-reset") => {
       setHardwareActionBusy(action);
@@ -688,6 +702,7 @@ function App() {
             onResetArmEmergencyStop={(armId) =>
               void handleUpdateArmSafety(armId, { emergency_stop: false }, `${armId}:reset-estop`)
             }
+            onResetArmState={(armId) => void handleResetArmState(armId)}
             onNeutralAll={() => void handleGlobalArmAction("neutral")}
             onEmergencyStop={() => void handleGlobalArmAction("emergency-stop")}
             onEmergencyReset={() => void handleGlobalArmAction("emergency-reset")}

--- a/frontend/src/components/hardware/hardware-status-dashboard.tsx
+++ b/frontend/src/components/hardware/hardware-status-dashboard.tsx
@@ -67,6 +67,7 @@ export function HardwareStatusDashboard({
   onToggleDryRun,
   onToggleTorque,
   onResetArmEmergencyStop,
+  onResetArmState,
   onNeutralAll,
   onEmergencyStop,
   onEmergencyReset,
@@ -81,6 +82,7 @@ export function HardwareStatusDashboard({
   onToggleDryRun: (armId: string, dryRun: boolean) => void;
   onToggleTorque: (armId: string, enabled: boolean) => void;
   onResetArmEmergencyStop: (armId: string) => void;
+  onResetArmState: (armId: string) => void;
   onNeutralAll: () => void;
   onEmergencyStop: () => void;
   onEmergencyReset: () => void;
@@ -241,7 +243,7 @@ export function HardwareStatusDashboard({
                     <StatusBlock label="Step Limit" value={`${arm.safety.max_step_degrees.toFixed(1)}°`} />
                   </div>
 
-                  <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="grid gap-3 sm:grid-cols-4">
                     <Button
                       variant={arm.safety.dry_run ? "secondary" : "ghost"}
                       disabled={busyAction !== null}
@@ -270,6 +272,13 @@ export function HardwareStatusDashboard({
                       onClick={() => onResetArmEmergencyStop(arm.arm_id)}
                     >
                       {busyAction === `${arm.arm_id}:reset-estop` ? "Resetting..." : "Clear Arm E-Stop"}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      disabled={busyAction !== null}
+                      onClick={() => onResetArmState(arm.arm_id)}
+                    >
+                      {busyAction === `${arm.arm_id}:reset-state` ? "Resetting..." : "Reset Arm"}
                     </Button>
                   </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -73,6 +73,12 @@ export function updateArmSafety(
   });
 }
 
+export function resetArmState(armId: string) {
+  return request<DualArmState>(`/api/arms/${armId}/reset-state`, {
+    method: "POST",
+  });
+}
+
 export function triggerEmergencyStop() {
   return request<DualArmState>("/api/arms/emergency-stop", {
     method: "POST",


### PR DESCRIPTION
## Summary
- add a stronger per-arm reset endpoint that fully resets safety/joint overrides and reconnects the arm into a sane live state
- add a Reset Arm button in the hardware dashboard
- cover the recovery path in the backend smoke test

## Verification
- backend/.venv/bin/python -m unittest discover -s backend/tests -v
- npm run build

## Notes
- this improves app-owned bad-state recovery, but it cannot steal a serial port from another process if the device is busy outside the app