### PR TITLE
feat: add dual-arm movement playback

### DIFF
--- a/backend/app/arms.py
+++ b/backend/app/arms.py
@@ -39,6 +39,7 @@ from .models import (
     MovementRunRequest,
     MovementRunState,
     MovementStatus,
+    MovementTargetScope,
     MotionCue,
     RobotConfig,
     SceneName,
@@ -511,7 +512,7 @@ class DualArmAdapter:
                 raise ValueError(arm.notes) from exc
             return
 
-        if self._movement_state.status == MovementStatus.RUNNING and self._movement_state.arm_id == arm_id:
+        if self._movement_state.status == MovementStatus.RUNNING and arm_id in self._movement_state.arm_ids:
             self.stop_movement()
         with self._command_lock:
             self.bridge.disconnect(arm)
@@ -593,7 +594,6 @@ class DualArmAdapter:
         )
 
     def start_movement(self, payload: MovementRunRequest) -> None:
-        arm = self._arm(payload.arm_id)
         definition = self._movement_definitions.get(payload.movement_id)
         spec = get_movement(payload.movement_id)
         if definition is None or spec is None:
@@ -601,25 +601,42 @@ class DualArmAdapter:
         if self._movement_state.status == MovementStatus.RUNNING:
             raise ValueError("A movement is already running")
 
-        self._assert_arm_ready_for_motion(arm)
+        target_arms = self._resolve_movement_arms(payload)
+        for arm in target_arms:
+            self._assert_arm_ready_for_motion(arm)
+
+        execution_mode = self._resolve_movement_execution_mode(payload)
         self._movement_stop.clear()
         now = datetime.now(UTC).isoformat()
+        selected_arm = target_arms[0] if payload.target_scope == MovementTargetScope.SINGLE else None
+        active_preset = payload.preset_id or definition.default_preset_id
+        target_label = (
+            selected_arm.arm_id
+            if selected_arm is not None
+            else ", ".join(arm.arm_id for arm in target_arms)
+        )
         self._movement_state = MovementRunState(
             status=MovementStatus.RUNNING,
             movement_id=payload.movement_id,
-            preset_id=payload.preset_id or definition.default_preset_id,
-            arm_id=arm.arm_id,
-            arm_type=arm.arm_type,
+            preset_id=active_preset,
+            target_scope=payload.target_scope,
+            execution_mode=execution_mode,
+            arm_id=selected_arm.arm_id if selected_arm is not None else None,
+            arm_ids=[arm.arm_id for arm in target_arms],
+            arm_type=selected_arm.arm_type if selected_arm is not None else None,
             started_at=now,
             updated_at=now,
-            note=f"Running {definition.name} ({payload.preset_id or definition.default_preset_id or 'default'}) on {arm.arm_id}.",
+            note=(
+                f"Running {definition.name} ({active_preset or 'default'}) "
+                f"in {execution_mode.value} mode on {target_label}."
+            ),
             progress=0.0,
         )
         self._movement_thread = Thread(
             target=self._run_movement_thread,
-            args=(payload, definition),
+            args=(payload, definition, target_arms, execution_mode),
             daemon=True,
-            name=f"movement-{payload.movement_id}-{arm.arm_id}",
+            name=f"movement-{payload.movement_id}-{payload.target_scope.value}",
         )
         self._movement_thread.start()
 
@@ -648,7 +665,7 @@ class DualArmAdapter:
         arm = self._arm(arm_id)
         was_connected = self.bridge.is_connected(arm)
 
-        if self._movement_state.status == MovementStatus.RUNNING and self._movement_state.arm_id == arm_id:
+        if self._movement_state.status == MovementStatus.RUNNING and arm_id in self._movement_state.arm_ids:
             self.stop_movement()
 
         if was_connected:
@@ -940,9 +957,10 @@ class DualArmAdapter:
         self,
         payload: MovementRunRequest,
         definition: MovementDefinition,
+        target_arms: list[ArmRuntime],
+        execution_mode: ExecutionMode,
     ) -> None:
         try:
-            arm = self._arm(payload.arm_id)
             generator = build_motion_generator(payload)
             total_duration = max(generator.duration_seconds, MOVEMENT_LOOP_INTERVAL_SECONDS)
             started = monotonic()
@@ -956,32 +974,72 @@ class DualArmAdapter:
                     self._movement_state.note = "Movement interrupted."
                     return
 
-                self._assert_arm_ready_for_motion(arm)
                 target = generator.sample(elapsed)
-                with self._command_lock:
-                    self._write_control_step(arm, target, reason=definition.name)
+                for arm in target_arms:
+                    self._assert_arm_ready_for_motion(arm)
+                    arm_target = self._movement_targets_for_arm(arm, target, execution_mode)
+                    with self._command_lock:
+                        self._write_control_step(arm, arm_target, reason=definition.name)
 
                 self._movement_state.progress = clamp(elapsed / total_duration, 0.0, 1.0)
                 self._movement_state.updated_at = datetime.now(UTC).isoformat()
                 active_preset = self._movement_state.preset_id or definition.default_preset_id or "default"
-                self._movement_state.note = f"{definition.name} ({active_preset}) in progress."
+                self._movement_state.note = (
+                    f"{definition.name} ({active_preset}) "
+                    f"{execution_mode.value} on {', '.join(self._movement_state.arm_ids)}."
+                )
                 sleep(MOVEMENT_LOOP_INTERVAL_SECONDS)
 
             self._movement_state.status = MovementStatus.COMPLETED
             self._movement_state.progress = 1.0
             self._movement_state.updated_at = datetime.now(UTC).isoformat()
             active_preset = self._movement_state.preset_id or definition.default_preset_id or "default"
-            self._movement_state.note = f"{definition.name} ({active_preset}) completed."
+            self._movement_state.note = (
+                f"{definition.name} ({active_preset}) "
+                f"{execution_mode.value} completed on {', '.join(self._movement_state.arm_ids)}."
+            )
         except Exception as exc:
             self._movement_state.status = MovementStatus.ERROR
             self._movement_state.updated_at = datetime.now(UTC).isoformat()
             self._movement_state.note = str(exc)
-            arm = self.arms.get(payload.arm_id)
-            if arm is not None:
-                arm.last_command_error = str(exc)
-                arm.notes = f"Movement error: {exc}"
+            for arm_id in self._movement_state.arm_ids or ([payload.arm_id] if payload.arm_id else []):
+                arm = self.arms.get(arm_id)
+                if arm is not None:
+                    arm.last_command_error = str(exc)
+                    arm.notes = f"Movement error: {exc}"
         finally:
             self._movement_thread = None
+
+    def _resolve_movement_execution_mode(self, payload: MovementRunRequest) -> ExecutionMode:
+        if payload.target_scope == MovementTargetScope.SINGLE:
+            return ExecutionMode.UNISON
+        return payload.execution_mode
+
+    def _resolve_movement_arms(self, payload: MovementRunRequest) -> list[ArmRuntime]:
+        if payload.target_scope == MovementTargetScope.SINGLE:
+            if not payload.arm_id:
+                raise ValueError("An arm_id is required for single-arm movement execution.")
+            return [self._arm(payload.arm_id)]
+
+        arms = sorted(self.arms.values(), key=lambda arm: arm.channel.value)
+        if len(arms) < 2:
+            raise ValueError("Dual-arm movement execution requires two configured arms.")
+        return arms
+
+    def _movement_targets_for_arm(
+        self,
+        arm: ArmRuntime,
+        targets: dict[str, float],
+        execution_mode: ExecutionMode,
+    ) -> dict[str, float]:
+        if execution_mode != ExecutionMode.MIRROR or arm.channel != ArmChannel.LEFT:
+            return dict(targets)
+
+        mirrored = dict(targets)
+        for joint_name in ("shoulder_pan", "wrist_roll"):
+            if joint_name in mirrored:
+                mirrored[joint_name] = round(-mirrored[joint_name], 2)
+        return mirrored
 
     def _write_control_step(self, arm: ArmRuntime, targets: dict[str, float], *, reason: str) -> None:
         current_servos = self.refresh_telemetry(arm.arm_id)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -101,6 +101,11 @@ class MovementStatus(str, Enum):
     ERROR = "error"
 
 
+class MovementTargetScope(str, Enum):
+    SINGLE = "single"
+    BOTH = "both"
+
+
 class RobotConfig(BaseModel):
     assembly: str = "Follower"
     follower_id: str = "follower_arm"
@@ -269,7 +274,10 @@ class MovementRunState(BaseModel):
     status: MovementStatus = MovementStatus.IDLE
     movement_id: str | None = None
     preset_id: str | None = None
+    target_scope: MovementTargetScope = MovementTargetScope.SINGLE
+    execution_mode: ExecutionMode = ExecutionMode.UNISON
     arm_id: str | None = None
+    arm_ids: list[str] = Field(default_factory=list)
     arm_type: ArmType | None = None
     started_at: str | None = None
     updated_at: str | None = None
@@ -356,7 +364,9 @@ class ExecutionModeUpdate(BaseModel):
 
 class MovementRunRequest(BaseModel):
     movement_id: str
-    arm_id: str
+    target_scope: MovementTargetScope = MovementTargetScope.SINGLE
+    execution_mode: ExecutionMode = ExecutionMode.UNISON
+    arm_id: str | None = None
     preset_id: str | None = None
     frequency_hz: float | None = Field(default=None, gt=0.1, le=4.0)
     cycles: int | None = Field(default=None, ge=1, le=32)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -287,6 +287,12 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertEqual(reset.status_code, 200)
         self.assertFalse(reset.json()["execution"]["emergency_stop_active"])
 
+        leader_reenable_after_reset = self.client.post(
+            "/api/arms/test_leader/safety",
+            json={"torque_enabled": True, "dry_run": False},
+        )
+        self.assertEqual(leader_reenable_after_reset.status_code, 200)
+
         follower_reenable = self.client.post(
             "/api/arms/test_follower/safety",
             json={"torque_enabled": True, "dry_run": False},
@@ -364,6 +370,9 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertIsNotNone(completed)
         self.assertEqual(completed["movement_id"], "wave")
         self.assertEqual(completed["arm_id"], "test_follower")
+        self.assertEqual(completed["target_scope"], "single")
+        self.assertEqual(completed["execution_mode"], "unison")
+        self.assertEqual(completed["arm_ids"], ["test_follower"])
         self.assertEqual(completed["preset_id"], "normal")
         self.assertGreaterEqual(completed["progress"], 1.0)
 
@@ -375,6 +384,42 @@ class ApiSmokeTest(unittest.TestCase):
         stop_wave = self.client.post("/api/movements/stop")
         self.assertEqual(stop_wave.status_code, 200)
         self.assertIn(stop_wave.json()["active"]["status"], {"stopped", "completed"})
+
+        dual_run = self.client.post(
+            "/api/movements/run",
+            json={
+                "movement_id": "wrist_lean",
+                "target_scope": "both",
+                "execution_mode": "mirror",
+                "preset_id": "normal",
+                "frequency_hz": 4.0,
+                "cycles": 1,
+            },
+        )
+        self.assertEqual(dual_run.status_code, 200)
+        self.assertEqual(dual_run.json()["active"]["status"], "running")
+        self.assertEqual(dual_run.json()["active"]["target_scope"], "both")
+        self.assertEqual(dual_run.json()["active"]["execution_mode"], "mirror")
+        self.assertEqual(set(dual_run.json()["active"]["arm_ids"]), {"test_leader", "test_follower"})
+
+        dual_completed = None
+        for _ in range(120):
+            snapshot = self.client.get("/api/movements")
+            self.assertEqual(snapshot.status_code, 200)
+            active = snapshot.json()["active"]
+            if active["status"] == "completed" and active["movement_id"] == "wrist_lean":
+                dual_completed = active
+                break
+            time.sleep(0.05)
+
+        self.assertIsNotNone(dual_completed)
+        self.assertEqual(dual_completed["target_scope"], "both")
+        self.assertEqual(dual_completed["execution_mode"], "mirror")
+        self.assertEqual(set(dual_completed["arm_ids"]), {"test_leader", "test_follower"})
+
+        bridge = main_module.store.arm_adapter.bridge
+        self.assertLess(bridge.goals["test_leader"]["shoulder_pan"], 0.0)
+        self.assertGreater(bridge.goals["test_follower"]["shoulder_pan"], 0.0)
 
         cache_files = list((Path(self.tempdir.name) / "analysis-cache" / "json" / "local").glob("*.json"))
         self.assertTrue(cache_files)

--- a/docs/IMPLEMENTATION_TRACKER.md
+++ b/docs/IMPLEMENTATION_TRACKER.md
@@ -27,11 +27,11 @@ The delivery sequence is:
 - `#30` Enforce live safety supervisor for torque, neutral, emergency stop, and step limits [done]
 - `#32` Add manual hardware validation controls and status surfaces [done]
 - `#38` Add live 2D dual-arm visualizer to robot dashboard [done]
-- `#34` Execute choreography on one live SO-101 arm
+- `#34` Execute choreography on one live SO-101 arm [done]
 - `#33` Run synchronized dual-arm choreography playback on leader + follower
 
 ## Current Status
-- Current PR target: `#45`
+- Current PR target: `#33`
 - Current backend state:
   - Search and track selection exist
   - Local upload and persistent local track metadata are available
@@ -45,8 +45,9 @@ The delivery sequence is:
   - Active bus sessions are now distinct from verification-ready state; `connected=true` means a live telemetry session is open
   - The backend now requires `feetech-servo-sdk` for real SO-101 telemetry through LeRobot
   - `#30` now enforces torque on/off, neutral moves, emergency stop, emergency reset, and live joint step limiting through the real Feetech write path
-  - `#34` now adds a movement library abstraction and a first executable oscillator-driven `wave` movement for one live arm
+  - `#34` now adds a movement library abstraction and live oscillator-driven gestures for one arm, including `wave` and `wrist_lean`
   - `#45` now adds terminal-first tooling to record manual SO-101 joint demonstrations, replay them through the existing safety path, and fit a cleaner wave preset from recordings
+  - `#33` now adds synchronized movement playback for both arms with `single`, `both-unison`, and `both-mirror` targeting
 - Current frontend state:
   - Home page is music-first
   - Search/select flow exists
@@ -57,7 +58,8 @@ The delivery sequence is:
   - Robot dashboard now shows real per-arm telemetry once a live connection is opened
   - `#38` added a responsive side-by-side 2D visualizer so both arms can be seen moving from live telemetry
   - `#30` added dashboard controls for dry-run, torque, neutral, and emergency-stop management
-  - `#34` adds a dedicated Movement Library page with arm selection, wave preset selection, and runtime tuning controls for the first live gesture
+  - `#34` adds a dedicated Movement Library page with arm selection, per-movement tuning, and live gesture execution
+  - `#33` extends the Movement Library page with single-arm vs dual-arm targeting and `mirror` / `unison` playback controls
   - `#45` adds terminal scripts for record/replay/fitting so manual observations can drive later motion refinement outside the UI
   - Music-driven choreography execution is not implemented yet, but the app can now execute a bounded library gesture on one live arm
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,7 +26,9 @@ import type {
   AnalysisStatusResponse,
   AudioAnalysis,
   ChoreographyTimeline,
+  ExecutionMode,
   MovementDefinition,
+  MovementTargetScope,
   RobotState,
   TrackSummary,
 } from "@/lib/types";
@@ -95,6 +97,8 @@ function App() {
   const [hardwareBusyArmId, setHardwareBusyArmId] = useState<string | null>(null);
   const [hardwareActionBusy, setHardwareActionBusy] = useState<string | null>(null);
   const [selectedMovementArmId, setSelectedMovementArmId] = useState<string | null>(null);
+  const [movementTargetScope, setMovementTargetScope] = useState<MovementTargetScope>("single");
+  const [movementExecutionMode, setMovementExecutionMode] = useState<ExecutionMode>("mirror");
   const [movementBusyAction, setMovementBusyAction] = useState<string | null>(null);
   const [movementTunings, setMovementTunings] = useState<Record<string, MovementTuning>>({});
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
@@ -461,7 +465,7 @@ function App() {
 
   const handleRunMovement = useCallback(
     async (movementId: string) => {
-      if (!selectedMovementArmId) {
+      if (movementTargetScope === "single" && !selectedMovementArmId) {
         setError("Select an arm before running a movement.");
         return;
       }
@@ -470,14 +474,22 @@ function App() {
       try {
         const movement = movementLibrary?.movements.find((entry) => entry.movement_id === movementId);
         const tuning = movement ? movementTunings[movementId] ?? defaultMovementTuning(movement) : null;
-        await runMovement(selectedMovementArmId, movementId, {
+        await runMovement(
+          movementId,
+          {
+            target_scope: movementTargetScope,
+            execution_mode: movementExecutionMode,
+            arm_id: movementTargetScope === "single" ? selectedMovementArmId ?? undefined : undefined,
+          },
+          {
           preset_id: tuning?.presetId,
           frequency_hz: tuning?.frequencyHz,
           cycles: tuning?.cycles,
           amplitude_scale: tuning?.amplitudeScale,
           softness: tuning?.softness,
           asymmetry: tuning ? clampAsymmetry(tuning.asymmetry) : undefined,
-        });
+          },
+        );
         await refreshState();
         setError(null);
       } catch (err) {
@@ -486,7 +498,7 @@ function App() {
         setMovementBusyAction(null);
       }
     },
-    [movementLibrary, movementTunings, selectedMovementArmId],
+    [movementExecutionMode, movementLibrary, movementTargetScope, movementTunings, selectedMovementArmId],
   );
 
   const handleStopMovement = useCallback(async () => {
@@ -695,9 +707,13 @@ function App() {
             library={movementLibrary}
             arms={state?.dual_arm.arms ?? []}
             selectedArmId={selectedMovementArmId}
+            targetScope={movementTargetScope}
+            executionMode={movementExecutionMode}
             movementTunings={movementTunings}
             busyAction={movementBusyAction}
             onSelectArm={setSelectedMovementArmId}
+            onSelectTargetScope={setMovementTargetScope}
+            onSelectExecutionMode={setMovementExecutionMode}
             onSelectPreset={(movementId, presetId) =>
               updateMovementTuning(movementId, (current) => {
                 const movement = movementLibrary?.movements.find((entry) => entry.movement_id === movementId);

--- a/frontend/src/components/movements/movement-library-page.tsx
+++ b/frontend/src/components/movements/movement-library-page.tsx
@@ -1,6 +1,12 @@
 import { Activity, Hand, Loader2, Play, Square, Waves } from "lucide-react";
 
-import type { ArmAdapterState, MovementDefinition, MovementLibraryState } from "@/lib/types";
+import type {
+  ArmAdapterState,
+  ExecutionMode,
+  MovementDefinition,
+  MovementLibraryState,
+  MovementTargetScope,
+} from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -31,9 +37,13 @@ export function MovementLibraryPage({
   library,
   arms,
   selectedArmId,
+  targetScope,
+  executionMode,
   movementTunings,
   busyAction,
   onSelectArm,
+  onSelectTargetScope,
+  onSelectExecutionMode,
   onSelectPreset,
   onFrequencyChange,
   onCyclesChange,
@@ -46,6 +56,8 @@ export function MovementLibraryPage({
   library: MovementLibraryState | null;
   arms: ArmAdapterState[];
   selectedArmId: string | null;
+  targetScope: MovementTargetScope;
+  executionMode: ExecutionMode;
   movementTunings: Record<
     string,
     {
@@ -59,6 +71,8 @@ export function MovementLibraryPage({
   >;
   busyAction: string | null;
   onSelectArm: (armId: string) => void;
+  onSelectTargetScope: (scope: MovementTargetScope) => void;
+  onSelectExecutionMode: (mode: ExecutionMode) => void;
   onSelectPreset: (movementId: string, presetId: string) => void;
   onFrequencyChange: (movementId: string, value: number) => void;
   onCyclesChange: (movementId: string, value: number) => void;
@@ -70,6 +84,9 @@ export function MovementLibraryPage({
 }) {
   const active = library?.active ?? {
     status: "idle" as const,
+    target_scope: "single" as const,
+    execution_mode: "unison" as const,
+    arm_ids: [],
     progress: 0,
   };
   const selectedArm = arms.find((arm) => arm.arm_id === selectedArmId) ?? null;
@@ -83,10 +100,10 @@ export function MovementLibraryPage({
             <Badge variant="accent">First Live Motion Path</Badge>
             <Badge variant="muted">{active.status === "running" ? "Movement Running" : "Ready"}</Badge>
           </div>
-          <CardTitle className="text-3xl text-white">Single-Arm Movement Studio</CardTitle>
+          <CardTitle className="text-3xl text-white">Movement Studio</CardTitle>
           <CardDescription className="max-w-3xl text-slate-300">
-            Start with reusable motion primitives before binding everything to music. The library now includes the
-            fitted `wave` plus a simpler `wrist_lean` built around upward wrist flex, shoulder pan, and a hand twist.
+            Start with reusable motion primitives before binding everything to music. You can now target one arm or
+            both arms together, and switch between `unison` and `mirror` playback for the same movement.
           </CardDescription>
         </CardHeader>
       </Card>
@@ -94,13 +111,78 @@ export function MovementLibraryPage({
       <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
         <Card className="border-white/10 bg-white/[0.04]">
           <CardHeader>
-            <CardTitle className="text-white">Arm Selection</CardTitle>
+            <CardTitle className="text-white">Execution Target</CardTitle>
             <CardDescription className="text-slate-300">
-              Choose the arm that should execute the movement. Live execution requires connection, torque enabled,
-              and dry run disabled.
+              Choose a single arm or run both arms together. Dual-arm playback reuses the same tuned movement with
+              `unison` or `mirror` coordination.
             </CardDescription>
           </CardHeader>
-          <CardContent className="grid gap-3 md:grid-cols-2">
+          <CardContent className="grid gap-4">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <button
+                className={`rounded-[24px] border p-4 text-left transition ${
+                  targetScope === "single"
+                    ? "border-primary/40 bg-primary/10 shadow-[0_16px_40px_rgba(12,74,162,0.18)]"
+                    : "border-white/10 bg-black/20 hover:border-white/20"
+                }`}
+                onClick={() => onSelectTargetScope("single")}
+                type="button"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge>Single Arm</Badge>
+                  <Badge variant="muted">Manual selection</Badge>
+                </div>
+                <p className="mt-4 text-sm text-slate-300">Run a movement on one arm at a time for tuning and checks.</p>
+              </button>
+              <button
+                className={`rounded-[24px] border p-4 text-left transition ${
+                  targetScope === "both"
+                    ? "border-primary/40 bg-primary/10 shadow-[0_16px_40px_rgba(12,74,162,0.18)]"
+                    : "border-white/10 bg-black/20 hover:border-white/20"
+                }`}
+                onClick={() => onSelectTargetScope("both")}
+                type="button"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge>Both Arms</Badge>
+                  <Badge variant="muted">{executionMode === "mirror" ? "Mirror" : "Unison"}</Badge>
+                </div>
+                <p className="mt-4 text-sm text-slate-300">
+                  Drive leader and follower together using the same movement runtime.
+                </p>
+              </button>
+            </div>
+
+            {targetScope === "both" ? (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <button
+                  className={`rounded-[20px] border px-4 py-3 text-left transition ${
+                    executionMode === "mirror"
+                      ? "border-primary/40 bg-primary/10 text-white"
+                      : "border-white/10 bg-white/[0.03] text-slate-300 hover:border-white/20"
+                  }`}
+                  onClick={() => onSelectExecutionMode("mirror")}
+                  type="button"
+                >
+                  <p className="text-sm font-semibold">Mirror</p>
+                  <p className="mt-1 text-xs text-slate-400">Oppose shoulder pan and wrist roll so the arms read symmetrically.</p>
+                </button>
+                <button
+                  className={`rounded-[20px] border px-4 py-3 text-left transition ${
+                    executionMode === "unison"
+                      ? "border-primary/40 bg-primary/10 text-white"
+                      : "border-white/10 bg-white/[0.03] text-slate-300 hover:border-white/20"
+                  }`}
+                  onClick={() => onSelectExecutionMode("unison")}
+                  type="button"
+                >
+                  <p className="text-sm font-semibold">Unison</p>
+                  <p className="mt-1 text-xs text-slate-400">Send the same joint trajectory to both arms together.</p>
+                </button>
+              </div>
+            ) : null}
+
+            <div className="grid gap-3 md:grid-cols-2">
             {arms.map((arm) => {
               const selected = arm.arm_id === selectedArmId;
               const ready = armReady(arm);
@@ -127,6 +209,7 @@ export function MovementLibraryPage({
                 </button>
               );
             })}
+            </div>
           </CardContent>
         </Card>
 
@@ -159,7 +242,10 @@ export function MovementLibraryPage({
           </CardHeader>
           <CardContent className="grid gap-4">
             {(library?.movements ?? []).map((movement) => {
-              const canRun = !!selectedArm && armReady(selectedArm) && active.status !== "running";
+              const readyArms = arms.filter((arm) => armReady(arm));
+              const canRun =
+                active.status !== "running" &&
+                (targetScope === "single" ? (!!selectedArm && armReady(selectedArm)) : readyArms.length >= 2);
               const isRunning = active.status === "running" && active.movement_id === movement.movement_id;
               const tuning = movementTunings[movement.movement_id] ?? defaultMovementTuning(movement);
               const selectedPreset =
@@ -196,7 +282,7 @@ export function MovementLibraryPage({
                         ) : (
                           <Play className="mr-2 h-4 w-4" />
                         )}
-                        {isRunning ? "Running..." : "Run Movement"}
+                        {isRunning ? "Running..." : targetScope === "both" ? "Run Both Arms" : "Run Movement"}
                       </Button>
                       <Button
                         variant="ghost"
@@ -339,7 +425,13 @@ export function MovementLibraryPage({
                 <Badge>{active.movement_id ?? "No movement"}</Badge>
                 <Badge variant={active.status === "running" ? "accent" : "muted"}>{active.status}</Badge>
                 {active.preset_id ? <Badge variant="muted">{active.preset_id}</Badge> : null}
-                {active.arm_id ? <Badge variant="muted">{active.arm_id}</Badge> : null}
+                <Badge variant="muted">{active.target_scope}</Badge>
+                <Badge variant="muted">{active.execution_mode}</Badge>
+                {(active.arm_ids ?? []).map((armId) => (
+                  <Badge key={armId} variant="muted">
+                    {armId}
+                  </Badge>
+                ))}
               </div>
               <p className="mt-4 text-sm text-slate-300">{active.note ?? "Pick an arm and run a movement."}</p>
               <div className="mt-5">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -102,8 +102,12 @@ export function fetchMovementLibrary() {
 }
 
 export function runMovement(
-  armId: string,
   movementId: string,
+  target: {
+    target_scope?: "single" | "both";
+    execution_mode?: "mirror" | "unison" | "call_response" | "asymmetric";
+    arm_id?: string;
+  },
   options?: {
     preset_id?: string;
     frequency_hz?: number;
@@ -115,7 +119,7 @@ export function runMovement(
 ) {
   return request<MovementLibraryState>("/api/movements/run", {
     method: "POST",
-    body: JSON.stringify({ arm_id: armId, movement_id: movementId, ...options }),
+    body: JSON.stringify({ movement_id: movementId, ...target, ...options }),
   });
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -10,6 +10,7 @@ export type ArmType = "follower" | "leader";
 export type ArmChannel = "left" | "right";
 export type ExecutionMode = "mirror" | "unison" | "call_response" | "asymmetric";
 export type MovementStatus = "idle" | "running" | "completed" | "stopped" | "error";
+export type MovementTargetScope = "single" | "both";
 export type ArmVerificationStatus =
   | "idle"
   | "ready"
@@ -276,7 +277,10 @@ export interface MovementRunState {
   status: MovementStatus;
   movement_id?: string | null;
   preset_id?: string | null;
+  target_scope: MovementTargetScope;
+  execution_mode: ExecutionMode;
   arm_id?: string | null;
+  arm_ids: string[];
   arm_type?: ArmType | null;
   started_at?: string | null;
   updated_at?: string | null;


### PR DESCRIPTION
Closes #33

## Summary
- add dual-arm movement execution for unison and mirror modes
- expose single-vs-both arm targeting in the Movement Library UI
- extend smoke coverage for mirrored two-arm runtime behavior

## Verification
- python3 -m compileall backend/app
- backend/.venv/bin/python -m unittest discover -s backend/tests -v
- npm run build