### PR TITLE
feat: add follow-through motion layer

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -258,6 +258,24 @@ class MovementJointProfile(BaseModel):
     bias: float = Field(default=0.0, ge=-90.0, le=90.0)
 
 
+class MovementFollowThroughProfile(BaseModel):
+    joint_name: str
+    source_joint: str
+    gain_ratio: float = Field(default=1.0, ge=0.0, le=2.0)
+    delay_ratio: float = Field(default=1.0, ge=0.0, le=2.0)
+    damping_ratio: float = Field(default=1.0, ge=0.0, le=2.0)
+    settle_ratio: float = Field(default=1.0, ge=0.0, le=2.0)
+
+
+class MovementFollowThroughConfig(BaseModel):
+    enabled: bool = True
+    delay_seconds: float = Field(default=0.12, ge=0.0, le=0.6)
+    gain: float = Field(default=0.2, ge=0.0, le=1.2)
+    damping: float = Field(default=0.4, ge=0.0, le=1.0)
+    settle: float = Field(default=0.14, ge=0.0, le=0.8)
+    profiles: list[MovementFollowThroughProfile] = Field(default_factory=list)
+
+
 class MovementPreset(BaseModel):
     preset_id: str
     label: str
@@ -268,6 +286,7 @@ class MovementPreset(BaseModel):
     softness: float = Field(default=0.7, ge=0.0, le=1.0)
     asymmetry: float = Field(default=0.0, ge=0.0, le=1.0)
     joint_profiles: list[MovementJointProfile] = Field(default_factory=list)
+    follow_through: MovementFollowThroughConfig = Field(default_factory=MovementFollowThroughConfig)
 
 
 class MovementRunState(BaseModel):
@@ -373,6 +392,11 @@ class MovementRunRequest(BaseModel):
     amplitude_scale: float | None = Field(default=None, ge=0.2, le=2.5)
     softness: float | None = Field(default=None, ge=0.0, le=1.0)
     asymmetry: float | None = Field(default=None, ge=0.0, le=1.0)
+    follow_through_enabled: bool | None = None
+    follow_through_delay_seconds: float | None = Field(default=None, ge=0.0, le=0.6)
+    follow_through_gain: float | None = Field(default=None, ge=0.0, le=1.2)
+    follow_through_damping: float | None = Field(default=None, ge=0.0, le=1.0)
+    follow_through_settle: float | None = Field(default=None, ge=0.0, le=0.8)
     debug: bool = False
 
 

--- a/backend/app/movement_library.py
+++ b/backend/app/movement_library.py
@@ -7,6 +7,8 @@ from typing import Protocol
 from .models import (
     ArmType,
     MovementDefinition,
+    MovementFollowThroughConfig,
+    MovementFollowThroughProfile,
     MovementJointProfile,
     MovementPreset,
     MovementRunRequest,
@@ -29,6 +31,10 @@ WRIST_LEAN_NEUTRAL_POSE = {
     "wrist_roll": 0.0,
     "gripper": 8.0,
 }
+
+
+def clamp(value: float, lower: float, upper: float) -> float:
+    return min(upper, max(lower, value))
 
 
 def _wave_profiles(scale: float) -> list[MovementJointProfile]:
@@ -97,6 +103,64 @@ def _wrist_lean_profiles(scale: float) -> list[MovementJointProfile]:
     ]
 
 
+def _wave_follow_through_profiles() -> list[MovementFollowThroughProfile]:
+    return [
+        MovementFollowThroughProfile(
+            joint_name="elbow_flex",
+            source_joint="shoulder_lift",
+            gain_ratio=0.55,
+            delay_ratio=0.8,
+            damping_ratio=1.05,
+            settle_ratio=0.7,
+        ),
+        MovementFollowThroughProfile(
+            joint_name="wrist_flex",
+            source_joint="elbow_flex",
+            gain_ratio=1.0,
+            delay_ratio=1.0,
+            damping_ratio=0.88,
+            settle_ratio=1.0,
+        ),
+        MovementFollowThroughProfile(
+            joint_name="wrist_roll",
+            source_joint="wrist_flex",
+            gain_ratio=1.12,
+            delay_ratio=1.22,
+            damping_ratio=0.82,
+            settle_ratio=1.18,
+        ),
+    ]
+
+
+def _wrist_lean_follow_through_profiles() -> list[MovementFollowThroughProfile]:
+    return [
+        MovementFollowThroughProfile(
+            joint_name="elbow_flex",
+            source_joint="shoulder_pan",
+            gain_ratio=0.26,
+            delay_ratio=0.68,
+            damping_ratio=1.0,
+            settle_ratio=0.4,
+        ),
+        MovementFollowThroughProfile(
+            joint_name="wrist_roll",
+            source_joint="wrist_flex",
+            gain_ratio=1.0,
+            delay_ratio=0.95,
+            damping_ratio=0.84,
+            settle_ratio=1.0,
+        ),
+        MovementFollowThroughProfile(
+            joint_name="gripper",
+            source_joint="wrist_roll",
+            gain_ratio=0.38,
+            delay_ratio=1.15,
+            damping_ratio=0.72,
+            settle_ratio=0.62,
+        ),
+    ]
+
+
 WAVE_PRESETS = {
     "subtle": MovementPreset(
         preset_id="subtle",
@@ -108,6 +172,14 @@ WAVE_PRESETS = {
         softness=0.88,
         asymmetry=0.08,
         joint_profiles=_wave_profiles(0.82),
+        follow_through=MovementFollowThroughConfig(
+            enabled=True,
+            delay_seconds=0.11,
+            gain=0.16,
+            damping=0.46,
+            settle=0.1,
+            profiles=_wave_follow_through_profiles(),
+        ),
     ),
     "normal": MovementPreset(
         preset_id="normal",
@@ -119,6 +191,14 @@ WAVE_PRESETS = {
         softness=0.72,
         asymmetry=0.0,
         joint_profiles=_wave_profiles(1.0),
+        follow_through=MovementFollowThroughConfig(
+            enabled=True,
+            delay_seconds=0.12,
+            gain=0.22,
+            damping=0.4,
+            settle=0.14,
+            profiles=_wave_follow_through_profiles(),
+        ),
     ),
     "exaggerated": MovementPreset(
         preset_id="exaggerated",
@@ -130,6 +210,14 @@ WAVE_PRESETS = {
         softness=0.62,
         asymmetry=0.24,
         joint_profiles=_wave_profiles(1.18),
+        follow_through=MovementFollowThroughConfig(
+            enabled=True,
+            delay_seconds=0.14,
+            gain=0.28,
+            damping=0.32,
+            settle=0.18,
+            profiles=_wave_follow_through_profiles(),
+        ),
     ),
 }
 
@@ -144,6 +232,14 @@ WRIST_LEAN_PRESETS = {
         softness=0.76,
         asymmetry=0.0,
         joint_profiles=_wrist_lean_profiles(1.0),
+        follow_through=MovementFollowThroughConfig(
+            enabled=True,
+            delay_seconds=0.08,
+            gain=0.18,
+            damping=0.44,
+            settle=0.1,
+            profiles=_wrist_lean_follow_through_profiles(),
+        ),
     ),
 }
 
@@ -159,6 +255,7 @@ class OscillatorRuntimeConfig:
     asymmetry: float
     neutral_pose: dict[str, float]
     joint_profiles: tuple[MovementJointProfile, ...]
+    follow_through: "FollowThroughRuntimeConfig"
     debug: bool = False
 
     @property
@@ -226,6 +323,118 @@ class OscillatorMotionGenerator:
 
 
 @dataclass(frozen=True)
+class FollowThroughRuntimeProfile:
+    joint_name: str
+    source_joint: str
+    gain_ratio: float
+    delay_ratio: float
+    damping_ratio: float
+    settle_ratio: float
+
+
+@dataclass(frozen=True)
+class FollowThroughRuntimeConfig:
+    enabled: bool
+    delay_seconds: float
+    gain: float
+    damping: float
+    settle: float
+    profiles: tuple[FollowThroughRuntimeProfile, ...]
+
+
+class FollowThroughMotionGenerator:
+    def __init__(
+        self,
+        base: MotionGenerator,
+        *,
+        neutral_pose: dict[str, float],
+        config: FollowThroughRuntimeConfig,
+    ) -> None:
+        self.base = base
+        self.duration_seconds = base.duration_seconds
+        self.neutral_pose = neutral_pose
+        self.config = config
+        self._history: list[tuple[float, dict[str, float]]] = []
+        self._last_output: dict[str, float] = {}
+
+    def sample(self, elapsed: float) -> dict[str, float]:
+        clamped_elapsed = max(0.0, min(elapsed, self.duration_seconds))
+        base_targets = dict(self.base.sample(clamped_elapsed))
+        self._remember_history(clamped_elapsed, base_targets)
+        if not self.config.enabled or not self.config.profiles:
+            self._last_output = dict(base_targets)
+            return base_targets
+
+        output = dict(base_targets)
+        for profile in self.config.profiles:
+            source_delay = self.config.delay_seconds * profile.delay_ratio
+            delayed_source = self._interpolate_joint(profile.source_joint, clamped_elapsed - source_delay)
+            previous_source = self._interpolate_joint(profile.source_joint, clamped_elapsed - source_delay - 0.04)
+            source_neutral = self.neutral_pose.get(profile.source_joint, delayed_source)
+            desired = base_targets.get(profile.joint_name, self.neutral_pose.get(profile.joint_name, 0.0))
+
+            damping = clamp(self.config.damping * profile.damping_ratio, 0.0, 1.0)
+            gain = self.config.gain * profile.gain_ratio * (1.0 - 0.45 * damping)
+            settle = self.config.settle * profile.settle_ratio * (1.0 - 0.22 * damping)
+            source_delta = delayed_source - source_neutral
+            source_velocity = (delayed_source - previous_source) / 0.04
+            desired += gain * source_delta
+            desired += settle * source_velocity
+
+            previous_output = self._last_output.get(profile.joint_name, base_targets.get(profile.joint_name, desired))
+            response_alpha = clamp(0.18 + (1.0 - damping) * 0.5, 0.18, 0.7)
+            output[profile.joint_name] = round(previous_output + response_alpha * (desired - previous_output), 2)
+
+        self._last_output = dict(output)
+        return output
+
+    def debug_samples(self, sample_hz: float = 30.0) -> list[dict[str, float]]:
+        sample_period = 1.0 / max(sample_hz, 1.0)
+        samples: list[dict[str, float]] = []
+        elapsed = 0.0
+        while elapsed <= self.duration_seconds + 1e-6:
+            frame = self.sample(elapsed)
+            frame["time"] = round(elapsed, 4)
+            samples.append(frame)
+            elapsed += sample_period
+        return samples
+
+    def _remember_history(self, elapsed: float, frame: dict[str, float]) -> None:
+        if self._history and elapsed < self._history[-1][0]:
+            self._history = []
+            self._last_output = {}
+        if self._history and abs(self._history[-1][0] - elapsed) < 1e-6:
+            self._history[-1] = (elapsed, dict(frame))
+        else:
+            self._history.append((elapsed, dict(frame)))
+        if len(self._history) > 240:
+            self._history = self._history[-240:]
+
+    def _interpolate_joint(self, joint_name: str, elapsed: float) -> float:
+        if not self._history:
+            return self.neutral_pose.get(joint_name, 0.0)
+        clamped_time = max(0.0, elapsed)
+        earlier = self._history[0]
+        later = self._history[-1]
+        for index, (frame_time, frame) in enumerate(self._history):
+            if frame_time >= clamped_time:
+                later = (frame_time, frame)
+                if index > 0:
+                    earlier = self._history[index - 1]
+                else:
+                    earlier = later
+                break
+        earlier_time, earlier_frame = earlier
+        later_time, later_frame = later
+        earlier_value = earlier_frame.get(joint_name, self.neutral_pose.get(joint_name, 0.0))
+        later_value = later_frame.get(joint_name, earlier_value)
+        if abs(later_time - earlier_time) < 1e-6:
+            return later_value
+        ratio = (clamped_time - earlier_time) / (later_time - earlier_time)
+        return earlier_value + (later_value - earlier_value) * ratio
+
+
+@dataclass(frozen=True)
 class MovementSpec:
     definition: MovementDefinition
 
@@ -281,7 +490,14 @@ def get_movement(movement_id: str) -> MovementSpec | None:
 
 def build_motion_generator(request: MovementRunRequest) -> MotionGenerator:
     config = resolve_oscillator_runtime(request)
-    return OscillatorMotionGenerator(config)
+    base_generator = OscillatorMotionGenerator(config)
+    if config.follow_through.enabled and config.follow_through.profiles:
+        return FollowThroughMotionGenerator(
+            base_generator,
+            neutral_pose=dict(config.neutral_pose),
+            config=config.follow_through,
+        )
+    return base_generator
 
 
 def resolve_oscillator_runtime(request: MovementRunRequest) -> OscillatorRuntimeConfig:
@@ -306,13 +522,47 @@ def resolve_oscillator_runtime(request: MovementRunRequest) -> OscillatorRuntime
         asymmetry=request.asymmetry if request.asymmetry is not None else preset.asymmetry,
         neutral_pose=dict(definition.neutral_pose),
         joint_profiles=tuple(profile.model_copy(deep=True) for profile in preset.joint_profiles),
+        follow_through=FollowThroughRuntimeConfig(
+            enabled=(
+                request.follow_through_enabled
+                if request.follow_through_enabled is not None
+                else preset.follow_through.enabled
+            ),
+            delay_seconds=(
+                request.follow_through_delay_seconds
+                if request.follow_through_delay_seconds is not None
+                else preset.follow_through.delay_seconds
+            ),
+            gain=request.follow_through_gain if request.follow_through_gain is not None else preset.follow_through.gain,
+            damping=(
+                request.follow_through_damping
+                if request.follow_through_damping is not None
+                else preset.follow_through.damping
+            ),
+            settle=(
+                request.follow_through_settle
+                if request.follow_through_settle is not None
+                else preset.follow_through.settle
+            ),
+            profiles=tuple(
+                FollowThroughRuntimeProfile(
+                    joint_name=profile.joint_name,
+                    source_joint=profile.source_joint,
+                    gain_ratio=profile.gain_ratio,
+                    delay_ratio=profile.delay_ratio,
+                    damping_ratio=profile.damping_ratio,
+                    settle_ratio=profile.settle_ratio,
+                )
+                for profile in preset.follow_through.profiles
+            ),
+        ),
         debug=request.debug,
     )
 
 
 def sample_motion(request: MovementRunRequest, sample_hz: float = 30.0) -> list[dict[str, float]]:
     generator = build_motion_generator(request)
-    if isinstance(generator, OscillatorMotionGenerator):
+    if isinstance(generator, (OscillatorMotionGenerator, FollowThroughMotionGenerator)):
         return generator.debug_samples(sample_hz=sample_hz)
 
     sample_period = 1.0 / max(sample_hz, 1.0)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -346,6 +346,7 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertEqual(wave_definition["controller"], "oscillator")
         self.assertEqual(wave_definition["default_preset_id"], "normal")
         self.assertEqual(len(wave_definition["presets"]), 3)
+        self.assertTrue(wave_definition["presets"][0]["follow_through"]["enabled"])
         self.assertEqual(wrist_lean_definition["controller"], "oscillator")
         self.assertEqual(wrist_lean_definition["default_preset_id"], "normal")
 
@@ -478,6 +479,34 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertLess(shoulder_peak_index, elbow_peak_index)
         self.assertLess(elbow_peak_index, wrist_peak_index)
         self.assertGreater(max(wrist_values) - min(wrist_values), max(shoulder_values) - min(shoulder_values))
+
+    def test_follow_through_increases_distal_motion(self) -> None:
+        base_samples = sample_motion(
+            MovementRunRequest(
+                movement_id="wave",
+                arm_id="test_follower",
+                preset_id="normal",
+                follow_through_enabled=False,
+            ),
+            sample_hz=80.0,
+        )
+        follow_samples = sample_motion(
+            MovementRunRequest(
+                movement_id="wave",
+                arm_id="test_follower",
+                preset_id="normal",
+                follow_through_enabled=True,
+                follow_through_gain=0.34,
+                follow_through_delay_seconds=0.14,
+                follow_through_damping=0.22,
+                follow_through_settle=0.22,
+            ),
+            sample_hz=80.0,
+        )
+
+        base_wrist_roll = [frame["wrist_roll"] for frame in base_samples]
+        follow_wrist_roll = [frame["wrist_roll"] for frame in follow_samples]
+        self.assertGreater(max(follow_wrist_roll) - min(follow_wrist_roll), max(base_wrist_roll) - min(base_wrist_roll))
 
 
 if __name__ == "__main__":

--- a/docs/IMPLEMENTATION_TRACKER.md
+++ b/docs/IMPLEMENTATION_TRACKER.md
@@ -10,6 +10,7 @@ The delivery sequence is:
 
 ## Active Epic
 - `#28` Phase 2: real dual-arm SO-101 execution for leader + follower
+- `#52` Add follow-through motion layer for live movements
 
 ## Ticket Stack
 - `#10` Define audio analysis models and API contracts for dual-arm choreography [done]
@@ -31,7 +32,7 @@ The delivery sequence is:
 - `#33` Run synchronized dual-arm choreography playback on leader + follower
 
 ## Current Status
-- Current PR target: `#33`
+- Current PR target: `#52`
 - Current backend state:
   - Search and track selection exist
   - Local upload and persistent local track metadata are available
@@ -48,6 +49,7 @@ The delivery sequence is:
   - `#34` now adds a movement library abstraction and live oscillator-driven gestures for one arm, including `wave` and `wrist_lean`
   - `#45` now adds terminal-first tooling to record manual SO-101 joint demonstrations, replay them through the existing safety path, and fit a cleaner wave preset from recordings
   - `#33` now adds synchronized movement playback for both arms with `single`, `both-unison`, and `both-mirror` targeting
+  - `#52` adds a follow-through layer on top of oscillator motions so distal joints can react with tunable delay, gain, damping, and settling
 - Current frontend state:
   - Home page is music-first
   - Search/select flow exists
@@ -60,6 +62,7 @@ The delivery sequence is:
   - `#30` added dashboard controls for dry-run, torque, neutral, and emergency-stop management
   - `#34` adds a dedicated Movement Library page with arm selection, per-movement tuning, and live gesture execution
   - `#33` extends the Movement Library page with single-arm vs dual-arm targeting and `mirror` / `unison` playback controls
+  - `#52` extends movement presets and UI tuning with follow-through controls so fluidity can be tuned before live execution
   - `#45` adds terminal scripts for record/replay/fitting so manual observations can drive later motion refinement outside the UI
   - Music-driven choreography execution is not implemented yet, but the app can now execute a bounded library gesture on one live arm
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,6 +54,11 @@ type MovementTuning = {
   amplitudeScale: number;
   softness: number;
   asymmetry: number;
+  followThroughEnabled: boolean;
+  followThroughDelaySeconds: number;
+  followThroughGain: number;
+  followThroughDamping: number;
+  followThroughSettle: number;
 };
 
 function defaultMovementTuning(movement: MovementDefinition): MovementTuning {
@@ -66,6 +71,11 @@ function defaultMovementTuning(movement: MovementDefinition): MovementTuning {
     amplitudeScale: defaultPreset?.amplitude_scale ?? 1.0,
     softness: defaultPreset?.softness ?? 0.72,
     asymmetry: defaultPreset?.asymmetry ?? 0.0,
+    followThroughEnabled: defaultPreset?.follow_through?.enabled ?? true,
+    followThroughDelaySeconds: defaultPreset?.follow_through?.delay_seconds ?? 0.12,
+    followThroughGain: defaultPreset?.follow_through?.gain ?? 0.2,
+    followThroughDamping: defaultPreset?.follow_through?.damping ?? 0.4,
+    followThroughSettle: defaultPreset?.follow_through?.settle ?? 0.14,
   };
 }
 
@@ -488,6 +498,11 @@ function App() {
           amplitude_scale: tuning?.amplitudeScale,
           softness: tuning?.softness,
           asymmetry: tuning ? clampAsymmetry(tuning.asymmetry) : undefined,
+          follow_through_enabled: tuning?.followThroughEnabled,
+          follow_through_delay_seconds: tuning?.followThroughDelaySeconds,
+          follow_through_gain: tuning?.followThroughGain,
+          follow_through_damping: tuning?.followThroughDamping,
+          follow_through_settle: tuning?.followThroughSettle,
           },
         );
         await refreshState();
@@ -730,6 +745,11 @@ function App() {
                   amplitudeScale: preset.amplitude_scale,
                   softness: preset.softness,
                   asymmetry: clampAsymmetry(preset.asymmetry),
+                  followThroughEnabled: preset.follow_through.enabled,
+                  followThroughDelaySeconds: preset.follow_through.delay_seconds,
+                  followThroughGain: preset.follow_through.gain,
+                  followThroughDamping: preset.follow_through.damping,
+                  followThroughSettle: preset.follow_through.settle,
                 };
               })
             }
@@ -747,6 +767,21 @@ function App() {
             }
             onAsymmetryChange={(movementId, value) =>
               updateMovementTuning(movementId, (current) => ({ ...current, asymmetry: clampAsymmetry(value) }))
+            }
+            onFollowThroughEnabledChange={(movementId, value) =>
+              updateMovementTuning(movementId, (current) => ({ ...current, followThroughEnabled: value }))
+            }
+            onFollowThroughDelayChange={(movementId, value) =>
+              updateMovementTuning(movementId, (current) => ({ ...current, followThroughDelaySeconds: value }))
+            }
+            onFollowThroughGainChange={(movementId, value) =>
+              updateMovementTuning(movementId, (current) => ({ ...current, followThroughGain: value }))
+            }
+            onFollowThroughDampingChange={(movementId, value) =>
+              updateMovementTuning(movementId, (current) => ({ ...current, followThroughDamping: value }))
+            }
+            onFollowThroughSettleChange={(movementId, value) =>
+              updateMovementTuning(movementId, (current) => ({ ...current, followThroughSettle: value }))
             }
             onRunMovement={(movementId) => void handleRunMovement(movementId)}
             onStopMovement={() => void handleStopMovement()}

--- a/frontend/src/components/movements/movement-library-page.tsx
+++ b/frontend/src/components/movements/movement-library-page.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
 
 const JOINT_GUIDE = [
   { name: "Shoulder Pan", role: "Sweeps the whole arm left and right." },
@@ -50,6 +51,11 @@ export function MovementLibraryPage({
   onAmplitudeScaleChange,
   onSoftnessChange,
   onAsymmetryChange,
+  onFollowThroughEnabledChange,
+  onFollowThroughDelayChange,
+  onFollowThroughGainChange,
+  onFollowThroughDampingChange,
+  onFollowThroughSettleChange,
   onRunMovement,
   onStopMovement,
 }: {
@@ -67,6 +73,11 @@ export function MovementLibraryPage({
       amplitudeScale: number;
       softness: number;
       asymmetry: number;
+      followThroughEnabled: boolean;
+      followThroughDelaySeconds: number;
+      followThroughGain: number;
+      followThroughDamping: number;
+      followThroughSettle: number;
     }
   >;
   busyAction: string | null;
@@ -79,6 +90,11 @@ export function MovementLibraryPage({
   onAmplitudeScaleChange: (movementId: string, value: number) => void;
   onSoftnessChange: (movementId: string, value: number) => void;
   onAsymmetryChange: (movementId: string, value: number) => void;
+  onFollowThroughEnabledChange: (movementId: string, value: boolean) => void;
+  onFollowThroughDelayChange: (movementId: string, value: number) => void;
+  onFollowThroughGainChange: (movementId: string, value: number) => void;
+  onFollowThroughDampingChange: (movementId: string, value: number) => void;
+  onFollowThroughSettleChange: (movementId: string, value: number) => void;
   onRunMovement: (movementId: string) => void;
   onStopMovement: () => void;
 }) {
@@ -253,6 +269,9 @@ export function MovementLibraryPage({
               const phaseChain = selectedPreset?.joint_profiles
                 .map((profile) => `${titleize(profile.joint_name)} ${profile.phase_delay_radians.toFixed(2)}rad`)
                 .join(" -> ");
+              const followThroughChain = selectedPreset?.follow_through.profiles
+                .map((profile) => `${titleize(profile.source_joint)} → ${titleize(profile.joint_name)}`)
+                .join(" • ");
 
               return (
                 <div
@@ -381,6 +400,67 @@ export function MovementLibraryPage({
                         />
                       </div>
 
+                      <div className="grid gap-4 rounded-[18px] border border-white/10 bg-white/[0.03] p-4">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-semibold text-white">Follow-Through Layer</p>
+                            <p className="mt-1 text-sm text-slate-400">
+                              Add delayed reactive motion so the gesture settles and propagates through the arm.
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-3">
+                            <Badge variant={tuning.followThroughEnabled ? "accent" : "muted"}>
+                              {tuning.followThroughEnabled ? "Enabled" : "Disabled"}
+                            </Badge>
+                            <Switch
+                              checked={tuning.followThroughEnabled}
+                              onCheckedChange={(value) => onFollowThroughEnabledChange(movement.movement_id, value)}
+                            />
+                          </div>
+                        </div>
+
+                        {tuning.followThroughEnabled ? (
+                          <div className="grid gap-4 xl:grid-cols-2">
+                            <TuningSlider
+                              label="Delay"
+                              value={tuning.followThroughDelaySeconds}
+                              display={`${tuning.followThroughDelaySeconds.toFixed(2)} s`}
+                              min={0}
+                              max={0.35}
+                              step={0.01}
+                              onChange={(value) => onFollowThroughDelayChange(movement.movement_id, value)}
+                            />
+                            <TuningSlider
+                              label="Gain"
+                              value={tuning.followThroughGain}
+                              display={tuning.followThroughGain.toFixed(2)}
+                              min={0}
+                              max={0.8}
+                              step={0.01}
+                              onChange={(value) => onFollowThroughGainChange(movement.movement_id, value)}
+                            />
+                            <TuningSlider
+                              label="Damping"
+                              value={tuning.followThroughDamping}
+                              display={tuning.followThroughDamping.toFixed(2)}
+                              min={0}
+                              max={1}
+                              step={0.01}
+                              onChange={(value) => onFollowThroughDampingChange(movement.movement_id, value)}
+                            />
+                            <TuningSlider
+                              label="Settle"
+                              value={tuning.followThroughSettle}
+                              display={tuning.followThroughSettle.toFixed(2)}
+                              min={0}
+                              max={0.5}
+                              step={0.01}
+                              onChange={(value) => onFollowThroughSettleChange(movement.movement_id, value)}
+                            />
+                          </div>
+                        ) : null}
+                      </div>
+
                       <div className="grid gap-3 lg:grid-cols-[1.1fr_0.9fr]">
                         <div className="rounded-[18px] border border-white/10 bg-white/[0.03] p-4">
                           <p className="text-sm font-semibold text-white">Prepared Base Pose</p>
@@ -402,6 +482,9 @@ export function MovementLibraryPage({
                             Proximal joints start first; distal joints finish the gesture.
                           </p>
                           <p className="mt-3 text-sm text-slate-200">{phaseChain ?? "No preset selected."}</p>
+                          {followThroughChain ? (
+                            <p className="mt-3 text-xs text-slate-400">Follow-through: {followThroughChain}</p>
+                          ) : null}
                         </div>
                       </div>
                     </div>
@@ -477,6 +560,11 @@ function defaultMovementTuning(movement: MovementDefinition) {
     amplitudeScale: preset?.amplitude_scale ?? 1,
     softness: preset?.softness ?? 0.72,
     asymmetry: preset?.asymmetry ?? 0,
+    followThroughEnabled: preset?.follow_through?.enabled ?? true,
+    followThroughDelaySeconds: preset?.follow_through?.delay_seconds ?? 0.12,
+    followThroughGain: preset?.follow_through?.gain ?? 0.2,
+    followThroughDamping: preset?.follow_through?.damping ?? 0.4,
+    followThroughSettle: preset?.follow_through?.settle ?? 0.14,
   };
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -115,6 +115,11 @@ export function runMovement(
     amplitude_scale?: number;
     softness?: number;
     asymmetry?: number;
+    follow_through_enabled?: boolean;
+    follow_through_delay_seconds?: number;
+    follow_through_gain?: number;
+    follow_through_damping?: number;
+    follow_through_settle?: number;
   },
 ) {
   return request<MovementLibraryState>("/api/movements/run", {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -261,6 +261,24 @@ export interface MovementJointProfile {
   bias: number;
 }
 
+export interface MovementFollowThroughProfile {
+  joint_name: string;
+  source_joint: string;
+  gain_ratio: number;
+  delay_ratio: number;
+  damping_ratio: number;
+  settle_ratio: number;
+}
+
+export interface MovementFollowThroughConfig {
+  enabled: boolean;
+  delay_seconds: number;
+  gain: number;
+  damping: number;
+  settle: number;
+  profiles: MovementFollowThroughProfile[];
+}
+
 export interface MovementPreset {
   preset_id: string;
   label: string;
@@ -271,6 +289,7 @@ export interface MovementPreset {
   softness: number;
   asymmetry: number;
   joint_profiles: MovementJointProfile[];
+  follow_through: MovementFollowThroughConfig;
 }
 
 export interface MovementRunState {


### PR DESCRIPTION
Closes #52

## Summary
- add a tunable follow-through layer on top of oscillator-driven live movements
- extend movement presets and run requests with follow-through controls
- expose follow-through tuning in the Movement Library UI

## Verification
- python3 -m compileall backend/app
- backend/.venv/bin/python -m unittest discover -s backend/tests -v
- npm run build