### PR TITLE
feat: add choreography scheduler

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from .models import (
     ArmConnectionUpdate,
     ArmSafetyUpdate,
     AudioAnalysis,
+    ChoreographySchedule,
     ChoreographyTimeline,
     DualArmState,
     ExecutionModeUpdate,
@@ -305,3 +306,24 @@ def get_choreography(source: TrackSource, track_id: str) -> ChoreographyTimeline
         raise HTTPException(status_code=409, detail=f"Choreography is waiting on analysis: {status.status}")
 
     raise HTTPException(status_code=404, detail="Choreography is not available yet")
+
+
+@app.get("/api/schedule/{source}/{track_id}", response_model=ChoreographySchedule)
+def get_schedule(source: TrackSource, track_id: str) -> ChoreographySchedule:
+    reference = TrackReference(track_id=track_id, source=source)
+    try:
+        cached = analysis_service.get_cached_analysis(reference)
+        if cached is not None:
+            store.store_analysis(cached)
+        schedule = store.get_schedule(reference)
+        status = store.get_analysis_status(reference)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    if schedule is not None:
+        return schedule
+
+    if status.status in {AnalysisStatus.QUEUED, AnalysisStatus.PROCESSING}:
+        raise HTTPException(status_code=409, detail=f"Schedule is waiting on analysis: {status.status}")
+
+    raise HTTPException(status_code=404, detail="Schedule is not available yet")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -309,6 +309,29 @@ class MovementLibraryState(BaseModel):
     active: MovementRunState = Field(default_factory=MovementRunState)
 
 
+class ScheduledMovementPhrase(BaseModel):
+    phrase_id: str
+    movement_id: str
+    preset_id: str
+    start_seconds: float = Field(ge=0.0)
+    end_seconds: float = Field(ge=0.0)
+    section_label: SectionLabel = SectionLabel.UNKNOWN
+    execution_mode: ExecutionMode = ExecutionMode.MIRROR
+    target_scope: MovementTargetScope = MovementTargetScope.BOTH
+    intensity: float = Field(default=0.5, ge=0.0, le=1.0)
+    density: float = Field(default=0.5, ge=0.0, le=1.0)
+    notes: str | None = None
+
+
+class ChoreographySchedule(BaseModel):
+    track_id: str
+    source: TrackSource
+    style_id: str = "baseline"
+    generated_at: str
+    phrase_count: int = Field(ge=0)
+    phrases: list[ScheduledMovementPhrase] = Field(default_factory=list)
+
+
 class RobotState(BaseModel):
     connected: bool
     status: str
@@ -326,6 +349,7 @@ class RobotState(BaseModel):
     servos: list[ServoState]
     dual_arm: DualArmState
     movement_library: MovementLibraryState
+    schedule: ChoreographySchedule | None = None
 
 
 class ModeUpdate(BaseModel):

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from .models import (
+    AudioAnalysis,
+    ChoreographySchedule,
+    ExecutionMode,
+    MovementDefinition,
+    ScheduledMovementPhrase,
+    SectionLabel,
+)
+
+
+class ChoreographyScheduler:
+    def __init__(self, movements: list[MovementDefinition]) -> None:
+        self.movements = {movement.movement_id: movement for movement in movements}
+
+    def build_schedule(self, analysis: AudioAnalysis, *, style_id: str = "baseline") -> ChoreographySchedule:
+        phrases: list[ScheduledMovementPhrase] = []
+        downbeats = analysis.downbeats or analysis.beats
+        beats = analysis.beats
+        phrase_index = 0
+
+        for section in analysis.sections:
+            movement_id, preset_id, execution_mode, beat_stride = self._section_plan(section)
+            movement = self.movements.get(movement_id)
+            if movement is None:
+                continue
+
+            phrase_starts = self._phrase_starts_for_section(section.start_seconds, section.end_seconds, downbeats, beats, beat_stride)
+            for start in phrase_starts:
+                duration = max(movement.duration_seconds, 0.6)
+                end = min(section.end_seconds, start + duration)
+                if end - start < 0.45:
+                    continue
+                phrases.append(
+                    ScheduledMovementPhrase(
+                        phrase_id=f"{movement_id}-{phrase_index}",
+                        movement_id=movement_id,
+                        preset_id=preset_id,
+                        start_seconds=round(start, 3),
+                        end_seconds=round(end, 3),
+                        section_label=section.label,
+                        execution_mode=execution_mode,
+                        intensity=round(section.energy_mean, 3),
+                        density=round(section.density_mean, 3),
+                        notes=f"{section.label.value} phrase aligned to beat grid",
+                    )
+                )
+                phrase_index += 1
+
+        return ChoreographySchedule(
+            track_id=analysis.track_id,
+            source=analysis.source,
+            style_id=style_id,
+            generated_at=datetime.now(UTC).isoformat(),
+            phrase_count=len(phrases),
+            phrases=phrases,
+        )
+
+    def _section_plan(self, section) -> tuple[str, str, ExecutionMode, int]:
+        if section.label in {SectionLabel.INTRO, SectionLabel.OUTRO, SectionLabel.BREAK}:
+            return "wrist_lean", "normal", ExecutionMode.UNISON, 2
+        if section.label == SectionLabel.CHORUS:
+            return "wave", "exaggerated", ExecutionMode.MIRROR, 1
+        if section.label == SectionLabel.BRIDGE:
+            return "wave", "subtle", ExecutionMode.UNISON, 2
+        if section.energy_mean >= 0.6:
+            return "wave", "normal", ExecutionMode.MIRROR, 1
+        return "wrist_lean", "normal", ExecutionMode.UNISON, 2
+
+    def _phrase_starts_for_section(
+        self,
+        start_seconds: float,
+        end_seconds: float,
+        downbeats: list[float],
+        beats: list[float],
+        beat_stride: int,
+    ) -> list[float]:
+        grid = [time for time in downbeats if start_seconds <= time < end_seconds]
+        if not grid:
+            grid = [time for time in beats if start_seconds <= time < end_seconds]
+        if not grid:
+            return [start_seconds]
+        return [time for index, time in enumerate(grid) if index % max(1, beat_stride) == 0]

--- a/backend/app/state.py
+++ b/backend/app/state.py
@@ -15,6 +15,7 @@ from .models import (
     ArmConnectionUpdate,
     ArmSafetyUpdate,
     AudioAnalysis,
+    ChoreographySchedule,
     ChoreographyTimeline,
     DanceMode,
     DualArmState,
@@ -37,6 +38,8 @@ from .models import (
     TransportState,
     TransportUpdate,
 )
+from .movement_library import list_movements
+from .scheduler import ChoreographyScheduler
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 SETUP_PATH = ROOT_DIR / ".data" / "setup.json"
@@ -112,6 +115,8 @@ class RobotStateStore:
         self.analysis_statuses: dict[tuple[TrackSource, str], AnalysisStatusResponse] = {}
         self.analysis_results: dict[tuple[TrackSource, str], AudioAnalysis] = {}
         self.choreography_results: dict[tuple[TrackSource, str], ChoreographyTimeline] = {}
+        self.schedule_results: dict[tuple[TrackSource, str], ChoreographySchedule] = {}
+        self.scheduler = ChoreographyScheduler(list_movements())
         self.servos = [
             ServoRuntime(id=servo_id, name=name, angle=0.0, target_angle=0.0)
             for servo_id, name in SERVO_LAYOUT
@@ -245,6 +250,7 @@ class RobotStateStore:
             servos=public_servos,
             dual_arm=dual_arm,
             movement_library=self.arm_adapter.movement_library_snapshot(),
+            schedule=self.current_schedule(),
         )
 
     def _build_spectrum(self) -> list[int]:
@@ -380,6 +386,12 @@ class RobotStateStore:
             return None
         return self.choreography_results.get(self._track_key(track.source, track.track_id))
 
+    def current_schedule(self) -> ChoreographySchedule | None:
+        track = self.transport.current_track
+        if track is None:
+            return None
+        return self.schedule_results.get(self._track_key(track.source, track.track_id))
+
     def arms_snapshot(self) -> DualArmState:
         self._tick()
         return self.arm_adapter.snapshot(self.current_choreography(), self.transport.position_seconds)
@@ -450,6 +462,7 @@ class RobotStateStore:
     def queue_analysis(self, payload: TrackReference) -> AnalysisStartResponse:
         self.analysis_results.pop(self._track_key(payload.source, payload.track_id), None)
         self.choreography_results.pop(self._track_key(payload.source, payload.track_id), None)
+        self.schedule_results.pop(self._track_key(payload.source, payload.track_id), None)
         status = AnalysisStatusResponse(
             track_id=payload.track_id,
             source=payload.source,
@@ -481,6 +494,10 @@ class RobotStateStore:
         self._status_for_reference(payload)
         return self.choreography_results.get(self._track_key(payload.source, payload.track_id))
 
+    def get_schedule(self, payload: TrackReference) -> ChoreographySchedule | None:
+        self._status_for_reference(payload)
+        return self.schedule_results.get(self._track_key(payload.source, payload.track_id))
+
     def remember_track(self, track: TrackSummary) -> TrackSummary:
         self.known_tracks[self._track_key(track.source, track.track_id)] = track
         return track
@@ -508,6 +525,7 @@ class RobotStateStore:
         key = self._track_key(analysis.source, analysis.track_id)
         self.analysis_results[key] = analysis
         self.choreography_results[key] = analysis.choreography
+        self.schedule_results[key] = self.scheduler.build_schedule(analysis)
 
         known_track = self.known_tracks.get(key)
         if known_track is not None:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -177,6 +177,8 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertAlmostEqual(state_payload["transport"]["energy"], payload["energy"]["rms"][0], places=3)
         expected_spectrum = self._expected_spectrum_prefix(payload)
         self.assertEqual(state_payload["spectrum"][:3], expected_spectrum)
+        self.assertIsNotNone(state_payload["schedule"])
+        self.assertGreater(state_payload["schedule"]["phrase_count"], 0)
         self.assertEqual(len(state_payload["dual_arm"]["arms"]), 2)
         self.assertEqual(state_payload["dual_arm"]["execution"]["mode"], "mirror")
 
@@ -194,6 +196,14 @@ class ApiSmokeTest(unittest.TestCase):
             any(cue["kind"] == "accent" for cue in choreography_payload["global_cues"])
             or any(cue["kind"] == "hold" for cue in choreography_payload["global_cues"])
         )
+
+        schedule = self.client.get(f"/api/schedule/{track['source']}/{track['track_id']}")
+        self.assertEqual(schedule.status_code, 200)
+        schedule_payload = schedule.json()
+        self.assertGreater(schedule_payload["phrase_count"], 0)
+        self.assertEqual(schedule_payload["phrase_count"], len(schedule_payload["phrases"]))
+        self.assertTrue(all(phrase["target_scope"] == "both" for phrase in schedule_payload["phrases"]))
+        self.assertTrue(all(phrase["execution_mode"] in {"mirror", "unison"} for phrase in schedule_payload["phrases"]))
 
         arms = self.client.get("/api/arms")
         self.assertEqual(arms.status_code, 200)

--- a/docs/IMPLEMENTATION_TRACKER.md
+++ b/docs/IMPLEMENTATION_TRACKER.md
@@ -9,8 +9,7 @@ The delivery sequence is:
 - Phase 3: optional leader-arm capture, phrase authoring, and smarter choreography tools
 
 ## Active Epic
-- `#28` Phase 2: real dual-arm SO-101 execution for leader + follower
-- `#52` Add follow-through motion layer for live movements
+- `#54` Phase 3: music-driven choreography and autonomous performance
 
 ## Ticket Stack
 - `#10` Define audio analysis models and API contracts for dual-arm choreography [done]
@@ -29,10 +28,14 @@ The delivery sequence is:
 - `#32` Add manual hardware validation controls and status surfaces [done]
 - `#38` Add live 2D dual-arm visualizer to robot dashboard [done]
 - `#34` Execute choreography on one live SO-101 arm [done]
-- `#33` Run synchronized dual-arm choreography playback on leader + follower
+- `#33` Run synchronized dual-arm choreography playback on leader + follower [done]
+- `#52` Add follow-through motion layer for live movements [done]
+- `#55` Build choreography scheduler from audio analysis to movement execution
+- `#57` Run autonomous music-driven dual-arm playback from the scheduler
+- `#56` Add song-level dance style controls and phrase mapping UI
 
 ## Current Status
-- Current PR target: `#52`
+- Current PR target: `#55`
 - Current backend state:
   - Search and track selection exist
   - Local upload and persistent local track metadata are available
@@ -50,6 +53,7 @@ The delivery sequence is:
   - `#45` now adds terminal-first tooling to record manual SO-101 joint demonstrations, replay them through the existing safety path, and fit a cleaner wave preset from recordings
   - `#33` now adds synchronized movement playback for both arms with `single`, `both-unison`, and `both-mirror` targeting
   - `#52` adds a follow-through layer on top of oscillator motions so distal joints can react with tunable delay, gain, damping, and settling
+  - `#55` is now adding a beat-aligned scheduler that converts analysis sections and beat grids into timed movement phrases
 - Current frontend state:
   - Home page is music-first
   - Search/select flow exists
@@ -64,7 +68,7 @@ The delivery sequence is:
   - `#33` extends the Movement Library page with single-arm vs dual-arm targeting and `mirror` / `unison` playback controls
   - `#52` extends movement presets and UI tuning with follow-through controls so fluidity can be tuned before live execution
   - `#45` adds terminal scripts for record/replay/fitting so manual observations can drive later motion refinement outside the UI
-  - Music-driven choreography execution is not implemented yet, but the app can now execute a bounded library gesture on one live arm
+  - Music-driven choreography execution is not implemented yet, but the app can now inspect scheduled phrase output for the selected track and execute bounded library gestures on one or both live arms
 
 ## Workflow Rule
 - Each ticket must ship from a feature branch through a pull request.
@@ -80,12 +84,9 @@ The delivery sequence is:
 - Persist computed audio analysis under `.data/analysis-cache/json/` and remote source audio under `.data/analysis-cache/audio/`.
 
 ## PR Order
-1. `#29` Live connection and calibration verification
-2. `#31` Real hardware bridge and telemetry
-3. `#30` Live safety supervisor
-4. `#32` Manual hardware validation controls
-5. `#34` Single-arm live choreography execution
-6. `#33` Dual-arm synchronized live choreography playback
+1. `#55` Choreography scheduler from audio analysis
+2. `#57` Autonomous dual-arm playback from the scheduler
+3. `#56` Song-level style controls and phrase mapping UI
 
 ## Update Rule
 After each merged PR:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -218,6 +218,7 @@ function App() {
   }, []);
 
   const currentTrack = state?.transport.current_track ?? null;
+  const currentSchedule = state?.schedule ?? null;
   const movementLibrary = state?.movement_library ?? null;
 
   useEffect(() => {
@@ -699,7 +700,7 @@ function App() {
                 </TabsContent>
 
                 <TabsContent value="structure" className="pt-6">
-                  <StructurePanel analysis={analysis} choreography={cueSummary} />
+                  <StructurePanel analysis={analysis} choreography={cueSummary} schedule={currentSchedule} />
                 </TabsContent>
 
                 <TabsContent value="track-info" className="pt-6">
@@ -707,6 +708,7 @@ function App() {
                     track={currentTrack}
                     analysis={analysis}
                     choreography={cueSummary}
+                    schedule={currentSchedule}
                     analysisStatus={analysisStatus}
                     analysisLoading={analysisLoading}
                     analysisError={analysisError}

--- a/frontend/src/components/analysis/structure-panel.tsx
+++ b/frontend/src/components/analysis/structure-panel.tsx
@@ -1,4 +1,4 @@
-import type { AudioAnalysis, ChoreographyTimeline } from "@/lib/types";
+import type { AudioAnalysis, ChoreographySchedule, ChoreographyTimeline } from "@/lib/types";
 
 import { formatDuration } from "@/lib/analysis-view";
 
@@ -9,9 +9,11 @@ function cueCountInWindow(times: number[], start: number, end: number) {
 export function StructurePanel({
   analysis,
   choreography,
+  schedule,
 }: {
   analysis: AudioAnalysis | null;
   choreography: ChoreographyTimeline | null;
+  schedule: ChoreographySchedule | null;
 }) {
   if (!analysis) {
     return <EmptyPanel text="Structure markers show up after the backend returns a section timeline." />;
@@ -82,6 +84,36 @@ export function StructurePanel({
             title="Arm Channels"
             note={choreography ? `${choreography.arm_left_cues.length} left-arm cues and ${choreography.arm_right_cues.length} right-arm cues are ready for the hardware bridge.` : "Arm-specific cue channels will appear with the choreography timeline."}
           />
+          <MappingBanner
+            title="Scheduled Phrases"
+            note={
+              schedule
+                ? `${schedule.phrase_count} scheduled movement phrases are ready for autonomous playback.`
+                : "Phrase scheduling appears after analysis is stored for the selected track."
+            }
+          />
+          {schedule ? (
+            <div className="rounded-[24px] border border-white/10 bg-white/[0.04] p-4">
+              <p className="text-base font-semibold text-white">First Scheduled Phrases</p>
+              <div className="mt-4 space-y-3">
+                {schedule.phrases.slice(0, 4).map((phrase) => (
+                  <div key={phrase.phrase_id} className="rounded-[18px] border border-white/10 bg-black/20 px-4 py-3">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <p className="text-sm font-semibold capitalize text-white">
+                        {phrase.movement_id} · {phrase.preset_id}
+                      </p>
+                      <p className="text-xs text-slate-400">
+                        {formatDuration(phrase.start_seconds)} - {formatDuration(phrase.end_seconds)}
+                      </p>
+                    </div>
+                    <p className="mt-2 text-xs text-slate-400">
+                      {phrase.section_label} · {phrase.execution_mode} · intensity {Math.round(phrase.intensity * 100)}%
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/frontend/src/components/analysis/track-info-panel.tsx
+++ b/frontend/src/components/analysis/track-info-panel.tsx
@@ -1,4 +1,10 @@
-import type { AnalysisStatusResponse, AudioAnalysis, ChoreographyTimeline, TrackSummary } from "@/lib/types";
+import type {
+  AnalysisStatusResponse,
+  AudioAnalysis,
+  ChoreographySchedule,
+  ChoreographyTimeline,
+  TrackSummary,
+} from "@/lib/types";
 
 import { formatDate, formatDuration } from "@/lib/analysis-view";
 
@@ -6,6 +12,7 @@ export function TrackInfoPanel({
   track,
   analysis,
   choreography,
+  schedule,
   analysisStatus,
   analysisLoading,
   analysisError,
@@ -13,6 +20,7 @@ export function TrackInfoPanel({
   track: TrackSummary | null;
   analysis: AudioAnalysis | null;
   choreography: ChoreographyTimeline | null;
+  schedule: ChoreographySchedule | null;
   analysisStatus: AnalysisStatusResponse | null;
   analysisLoading: boolean;
   analysisError: string | null;
@@ -54,10 +62,19 @@ export function TrackInfoPanel({
                   : "Choreography cues appear after the analysis payload is loaded."
             }
           />
-          <div className="grid gap-4 sm:grid-cols-3">
+          <Banner
+            title={schedule ? "Scheduler ready" : "Scheduler pending"}
+            note={
+              schedule
+                ? `${schedule.phrase_count} phrase windows are mapped from the current analysis for future autonomous playback.`
+                : "The phrase scheduler appears after analysis is available for the selected track."
+            }
+          />
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
             <InfoTile label="Sample Rate" value={analysis ? `${analysis.sample_rate} Hz` : "--"} />
             <InfoTile label="Waveform Buckets" value={analysis ? `${analysis.waveform.bucket_count}` : "--"} />
             <InfoTile label="Tempo Confidence" value={analysis ? `${Math.round(analysis.tempo_confidence * 100)}%` : "--"} />
+            <InfoTile label="Phrases" value={schedule ? `${schedule.phrase_count}` : "--"} />
           </div>
         </div>
       </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   AnalysisStartResponse,
   AnalysisStatusResponse,
   AudioAnalysis,
+  ChoreographySchedule,
   ChoreographyTimeline,
   DanceMode,
   DualArmState,
@@ -225,4 +226,8 @@ export function fetchAnalysis(trackId: string, source: TrackSource) {
 
 export function fetchChoreography(trackId: string, source: TrackSource) {
   return request<ChoreographyTimeline>(`/api/choreography/${source}/${trackId}`);
+}
+
+export function fetchSchedule(trackId: string, source: TrackSource) {
+  return request<ChoreographySchedule>(`/api/schedule/${source}/${trackId}`);
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -111,6 +111,29 @@ export interface ChoreographyTimeline {
   arm_right_cues: MotionCue[];
 }
 
+export interface ScheduledMovementPhrase {
+  phrase_id: string;
+  movement_id: string;
+  preset_id: string;
+  start_seconds: number;
+  end_seconds: number;
+  section_label: SectionLabel;
+  execution_mode: ExecutionMode;
+  target_scope: MovementTargetScope;
+  intensity: number;
+  density: number;
+  notes?: string | null;
+}
+
+export interface ChoreographySchedule {
+  track_id: string;
+  source: TrackSource;
+  style_id: string;
+  generated_at: string;
+  phrase_count: number;
+  phrases: ScheduledMovementPhrase[];
+}
+
 export interface AudioAnalysis {
   track_id: string;
   source: TrackSource;
@@ -329,4 +352,5 @@ export interface RobotState {
   servos: ServoState[];
   dual_arm: DualArmState;
   movement_library: MovementLibraryState;
+  schedule?: ChoreographySchedule | null;
 }


### PR DESCRIPTION
Closes #55

## Summary
- add a backend scheduler that converts analysis sections and beat grids into timed movement phrases
- expose the current track schedule through state and a dedicated API endpoint
- surface scheduled phrases in the analysis UI for inspection

## Verification
- python3 -m compileall backend/app
- backend/.venv/bin/python -m unittest discover -s backend/tests -v
- npm run build