### PR TITLE
feat: add autonomous scheduler playback

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -175,6 +175,19 @@ def stop_movement() -> MovementLibraryState:
     return store.stop_movement()
 
 
+@app.post("/api/autonomy/start", response_model=RobotState)
+def start_autonomy() -> RobotState:
+    try:
+        return store.start_autonomy()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/api/autonomy/stop", response_model=RobotState)
+def stop_autonomy() -> RobotState:
+    return store.stop_autonomy()
+
+
 @app.get("/api/tracks/search", response_model=TrackSearchResponse)
 def search_tracks(
     q: str,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -106,6 +106,13 @@ class MovementTargetScope(str, Enum):
     BOTH = "both"
 
 
+class AutonomyStatus(str, Enum):
+    IDLE = "idle"
+    ARMED = "armed"
+    RUNNING = "running"
+    ERROR = "error"
+
+
 class RobotConfig(BaseModel):
     assembly: str = "Follower"
     follower_id: str = "follower_arm"
@@ -332,6 +339,15 @@ class ChoreographySchedule(BaseModel):
     phrases: list[ScheduledMovementPhrase] = Field(default_factory=list)
 
 
+class AutonomousPerformanceState(BaseModel):
+    status: AutonomyStatus = AutonomyStatus.IDLE
+    active_phrase_id: str | None = None
+    current_phrase: ScheduledMovementPhrase | None = None
+    next_phrase_id: str | None = None
+    note: str | None = None
+    last_transition_at: str | None = None
+
+
 class RobotState(BaseModel):
     connected: bool
     status: str
@@ -350,6 +366,7 @@ class RobotState(BaseModel):
     dual_arm: DualArmState
     movement_library: MovementLibraryState
     schedule: ChoreographySchedule | None = None
+    autonomy: AutonomousPerformanceState = Field(default_factory=AutonomousPerformanceState)
 
 
 class ModeUpdate(BaseModel):

--- a/backend/app/state.py
+++ b/backend/app/state.py
@@ -9,6 +9,8 @@ from time import monotonic
 
 from .arms import ArmHardwareBridge, DEFAULT_JOINT_LAYOUT, DualArmAdapter, LeRobotArmVerifier
 from .models import (
+    AutonomousPerformanceState,
+    AutonomyStatus,
     AnalysisStartResponse,
     AnalysisStatus,
     AnalysisStatusResponse,
@@ -105,6 +107,7 @@ class RobotStateStore:
         self.arm_adapter = DualArmAdapter(self.config, verifier=verifier, bridge=bridge)
         self.mode = DanceMode.IDLE
         self.transport = TransportState()
+        self.autonomy = AutonomousPerformanceState(note="Autonomous scheduler idle.")
         self.status = "ready"
         self.latency_ms = 14
         self.sync_quality = 92
@@ -145,7 +148,10 @@ class RobotStateStore:
 
         analysis = self.current_analysis()
         choreography = self.current_choreography()
+        schedule = self.current_schedule()
         self._sync_transport_from_analysis(analysis)
+        if self.mode == DanceMode.AUTONOMOUS:
+            self._tick_autonomous_schedule(schedule, analysis.duration_seconds if analysis is not None else None)
 
         beat = self.transport.position_seconds * max(self.transport.bpm, 1) / 60.0
         beat_phase = beat * math.tau
@@ -251,6 +257,7 @@ class RobotStateStore:
             dual_arm=dual_arm,
             movement_library=self.arm_adapter.movement_library_snapshot(),
             schedule=self.current_schedule(),
+            autonomy=self.autonomy.model_copy(deep=True),
         )
 
     def _build_spectrum(self) -> list[int]:
@@ -281,6 +288,8 @@ class RobotStateStore:
     def set_mode(self, mode: DanceMode) -> RobotState:
         if self.arm_adapter.emergency_stop_active() and mode != DanceMode.IDLE:
             mode = DanceMode.IDLE
+        if mode != DanceMode.AUTONOMOUS and self.mode == DanceMode.AUTONOMOUS:
+            self._clear_autonomy_state("Autonomous scheduler idle.")
         self.mode = mode
         if mode == DanceMode.IDLE:
             self.apply_scene(SceneName.IDLE)
@@ -326,6 +335,7 @@ class RobotStateStore:
         return self.snapshot()
 
     def select_track(self, payload: TrackSelection) -> RobotState:
+        self._clear_autonomy_state("Track changed. Autonomous scheduler reset.")
         track = payload.track
         self.remember_track(track)
         key = self._track_key(track.source, track.track_id)
@@ -428,6 +438,7 @@ class RobotStateStore:
         self.arm_adapter.emergency_stop()
         self.transport.playing = False
         self.mode = DanceMode.IDLE
+        self._clear_autonomy_state("Emergency stop engaged.")
         self._set_scene_targets(SceneName.IDLE)
         self._sync_follower_torque_state()
         return self.arms_snapshot()
@@ -441,6 +452,7 @@ class RobotStateStore:
         self.arm_adapter.neutralize()
         self.transport.playing = False
         self.mode = DanceMode.IDLE
+        self._clear_autonomy_state("Moved to neutral pose.")
         self._set_scene_targets(SceneName.IDLE)
         return self.arms_snapshot()
 
@@ -449,6 +461,7 @@ class RobotStateStore:
         return self.arm_adapter.movement_library_snapshot()
 
     def run_movement(self, payload: MovementRunRequest) -> MovementLibraryState:
+        self._clear_autonomy_state("Manual movement requested.")
         self.arm_adapter.start_movement(payload)
         self.mode = DanceMode.MANUAL
         self.transport.playing = False
@@ -456,8 +469,34 @@ class RobotStateStore:
 
     def stop_movement(self) -> MovementLibraryState:
         self.arm_adapter.stop_movement()
-        self.mode = DanceMode.IDLE
+        if self.mode != DanceMode.AUTONOMOUS:
+            self.mode = DanceMode.IDLE
         return self.movement_library()
+
+    def start_autonomy(self) -> RobotState:
+        if self.transport.current_track is None:
+            raise ValueError("Select a track before starting autonomous playback.")
+        schedule = self.current_schedule()
+        if schedule is None or schedule.phrase_count == 0:
+            raise ValueError("No schedule is available for the selected track.")
+
+        self.transport.position_seconds = 0.0
+        self.transport.playing = True
+        self.mode = DanceMode.AUTONOMOUS
+        self.autonomy = AutonomousPerformanceState(
+            status=AutonomyStatus.ARMED,
+            note="Autonomous scheduler armed. Waiting for the first scheduled phrase.",
+            next_phrase_id=schedule.phrases[0].phrase_id if schedule.phrases else None,
+            last_transition_at=datetime.now(UTC).isoformat(),
+        )
+        return self.snapshot()
+
+    def stop_autonomy(self) -> RobotState:
+        self.arm_adapter.stop_movement()
+        self.transport.playing = False
+        self.mode = DanceMode.IDLE
+        self._clear_autonomy_state("Autonomous playback stopped.")
+        return self.snapshot()
 
     def queue_analysis(self, payload: TrackReference) -> AnalysisStartResponse:
         self.analysis_results.pop(self._track_key(payload.source, payload.track_id), None)
@@ -576,6 +615,74 @@ class RobotStateStore:
         self.transport.bpm = max(40, min(220, int(round(analysis.bpm or self.transport.bpm))))
         frame_index = self._analysis_frame_index(analysis)
         self.transport.energy = round(self._series_value(analysis.energy.rms, frame_index), 3)
+
+    def _tick_autonomous_schedule(self, schedule: ChoreographySchedule | None, duration_seconds: float | None) -> None:
+        if schedule is None or not schedule.phrases:
+            self.autonomy.status = AutonomyStatus.ERROR
+            self.autonomy.note = "No scheduled phrases are available for autonomous playback."
+            self.transport.playing = False
+            self.mode = DanceMode.IDLE
+            return
+
+        position = self.transport.position_seconds
+        current_phrase = next((phrase for phrase in schedule.phrases if phrase.start_seconds <= position < phrase.end_seconds), None)
+        next_phrase = next((phrase for phrase in schedule.phrases if phrase.start_seconds > position), None)
+
+        if current_phrase is None:
+            if next_phrase is not None:
+                self.autonomy.status = AutonomyStatus.ARMED
+                self.autonomy.active_phrase_id = None
+                self.autonomy.current_phrase = None
+                self.autonomy.next_phrase_id = next_phrase.phrase_id
+                self.autonomy.note = f"Waiting for {next_phrase.movement_id} at {next_phrase.start_seconds:.2f}s."
+            else:
+                if self.arm_adapter.movement_library_snapshot().active.status.value == "running":
+                    self.arm_adapter.stop_movement()
+                self.transport.playing = False
+                self.mode = DanceMode.IDLE
+                self._clear_autonomy_state("Autonomous playback completed.")
+            return
+
+        self.autonomy.next_phrase_id = next_phrase.phrase_id if next_phrase is not None else None
+        if self.autonomy.active_phrase_id != current_phrase.phrase_id:
+            if self.arm_adapter.movement_library_snapshot().active.status.value == "running":
+                self.arm_adapter.stop_movement()
+            try:
+                self.arm_adapter.start_movement(
+                    MovementRunRequest(
+                        movement_id=current_phrase.movement_id,
+                        target_scope=current_phrase.target_scope,
+                        execution_mode=current_phrase.execution_mode,
+                        preset_id=current_phrase.preset_id,
+                    )
+                )
+            except ValueError as exc:
+                self.autonomy.status = AutonomyStatus.ERROR
+                self.autonomy.note = str(exc)
+                self.transport.playing = False
+                self.mode = DanceMode.IDLE
+                return
+            self.autonomy.active_phrase_id = current_phrase.phrase_id
+            self.autonomy.current_phrase = current_phrase
+            self.autonomy.status = AutonomyStatus.RUNNING
+            self.autonomy.note = f"{current_phrase.movement_id} ({current_phrase.execution_mode.value}) is running."
+            self.autonomy.last_transition_at = datetime.now(UTC).isoformat()
+        else:
+            self.autonomy.status = AutonomyStatus.RUNNING
+            self.autonomy.current_phrase = current_phrase
+            self.autonomy.note = f"{current_phrase.movement_id} ({current_phrase.execution_mode.value}) is running."
+
+        if duration_seconds is not None and position >= duration_seconds:
+            self.transport.playing = False
+            self.mode = DanceMode.IDLE
+            self._clear_autonomy_state("Autonomous playback completed.")
+
+    def _clear_autonomy_state(self, note: str) -> None:
+        self.autonomy = AutonomousPerformanceState(
+            status=AutonomyStatus.IDLE,
+            note=note,
+            last_transition_at=datetime.now(UTC).isoformat(),
+        )
 
     def _analysis_frame_index(self, analysis: AudioAnalysis) -> int:
         if analysis.energy.frame_hz <= 0 or not analysis.energy.rms:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -432,6 +432,34 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertLess(bridge.goals["test_leader"]["shoulder_pan"], 0.0)
         self.assertGreater(bridge.goals["test_follower"]["shoulder_pan"], 0.0)
 
+        autonomy_start = self.client.post("/api/autonomy/start")
+        self.assertEqual(autonomy_start.status_code, 200)
+        autonomy_payload = autonomy_start.json()
+        self.assertEqual(autonomy_payload["mode"], "autonomous")
+        self.assertTrue(autonomy_payload["transport"]["playing"])
+        self.assertEqual(autonomy_payload["autonomy"]["status"], "armed")
+
+        autonomy_running = None
+        for _ in range(120):
+            snapshot = self.client.get("/api/state")
+            self.assertEqual(snapshot.status_code, 200)
+            state_live = snapshot.json()
+            if state_live["autonomy"]["status"] == "running" and state_live["autonomy"]["current_phrase"] is not None:
+                autonomy_running = state_live["autonomy"]
+                break
+            time.sleep(0.05)
+
+        self.assertIsNotNone(autonomy_running)
+        self.assertIn(autonomy_running["current_phrase"]["movement_id"], {"wave", "wrist_lean"})
+        self.assertIn(autonomy_running["current_phrase"]["execution_mode"], {"mirror", "unison"})
+
+        autonomy_stop = self.client.post("/api/autonomy/stop")
+        self.assertEqual(autonomy_stop.status_code, 200)
+        stop_payload = autonomy_stop.json()
+        self.assertEqual(stop_payload["mode"], "idle")
+        self.assertFalse(stop_payload["transport"]["playing"])
+        self.assertEqual(stop_payload["autonomy"]["status"], "idle")
+
         cache_files = list((Path(self.tempdir.name) / "analysis-cache" / "json" / "local").glob("*.json"))
         self.assertTrue(cache_files)
 

--- a/docs/IMPLEMENTATION_TRACKER.md
+++ b/docs/IMPLEMENTATION_TRACKER.md
@@ -30,12 +30,12 @@ The delivery sequence is:
 - `#34` Execute choreography on one live SO-101 arm [done]
 - `#33` Run synchronized dual-arm choreography playback on leader + follower [done]
 - `#52` Add follow-through motion layer for live movements [done]
-- `#55` Build choreography scheduler from audio analysis to movement execution
+- `#55` Build choreography scheduler from audio analysis to movement execution [done]
 - `#57` Run autonomous music-driven dual-arm playback from the scheduler
 - `#56` Add song-level dance style controls and phrase mapping UI
 
 ## Current Status
-- Current PR target: `#55`
+- Current PR target: `#57`
 - Current backend state:
   - Search and track selection exist
   - Local upload and persistent local track metadata are available
@@ -53,7 +53,8 @@ The delivery sequence is:
   - `#45` now adds terminal-first tooling to record manual SO-101 joint demonstrations, replay them through the existing safety path, and fit a cleaner wave preset from recordings
   - `#33` now adds synchronized movement playback for both arms with `single`, `both-unison`, and `both-mirror` targeting
   - `#52` adds a follow-through layer on top of oscillator motions so distal joints can react with tunable delay, gain, damping, and settling
-  - `#55` is now adding a beat-aligned scheduler that converts analysis sections and beat grids into timed movement phrases
+  - `#55` now adds a beat-aligned scheduler that converts analysis sections and beat grids into timed movement phrases
+  - `#57` now adds autonomous playback controls that arm the transport, trigger scheduled phrases on time, and stop cleanly when the schedule completes or is cancelled
 - Current frontend state:
   - Home page is music-first
   - Search/select flow exists
@@ -68,7 +69,8 @@ The delivery sequence is:
   - `#33` extends the Movement Library page with single-arm vs dual-arm targeting and `mirror` / `unison` playback controls
   - `#52` extends movement presets and UI tuning with follow-through controls so fluidity can be tuned before live execution
   - `#45` adds terminal scripts for record/replay/fitting so manual observations can drive later motion refinement outside the UI
-  - Music-driven choreography execution is not implemented yet, but the app can now inspect scheduled phrase output for the selected track and execute bounded library gestures on one or both live arms
+  - `#55` lets the app inspect scheduled phrase output for the selected track
+  - `#57` is now wiring autonomous transport control so scheduled phrases execute live on one or both arms from the Track Info page
 
 ## Workflow Rule
 - Each ticket must ship from a feature branch through a pull request.
@@ -84,9 +86,8 @@ The delivery sequence is:
 - Persist computed audio analysis under `.data/analysis-cache/json/` and remote source audio under `.data/analysis-cache/audio/`.
 
 ## PR Order
-1. `#55` Choreography scheduler from audio analysis
-2. `#57` Autonomous dual-arm playback from the scheduler
-3. `#56` Song-level style controls and phrase mapping UI
+1. `#57` Autonomous dual-arm playback from the scheduler
+2. `#56` Song-level style controls and phrase mapping UI
 
 ## Update Rule
 After each merged PR:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,8 +15,10 @@ import {
   setArmConnection,
   selectTrack,
   setTransport,
+  startAutonomy,
   startAnalysis,
   stopMovement,
+  stopAutonomy,
   triggerEmergencyStop,
   updateArmSafety,
   uploadTrack,
@@ -110,6 +112,7 @@ function App() {
   const [movementTargetScope, setMovementTargetScope] = useState<MovementTargetScope>("single");
   const [movementExecutionMode, setMovementExecutionMode] = useState<ExecutionMode>("mirror");
   const [movementBusyAction, setMovementBusyAction] = useState<string | null>(null);
+  const [autonomyBusy, setAutonomyBusy] = useState(false);
   const [movementTunings, setMovementTunings] = useState<Record<string, MovementTuning>>({});
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -530,6 +533,30 @@ function App() {
     }
   }, []);
 
+  const handleStartAutonomy = useCallback(async () => {
+    setAutonomyBusy(true);
+    try {
+      await commitAction(() => startAutonomy());
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to start autonomous playback");
+    } finally {
+      setAutonomyBusy(false);
+    }
+  }, []);
+
+  const handleStopAutonomy = useCallback(async () => {
+    setAutonomyBusy(true);
+    try {
+      await commitAction(() => stopAutonomy());
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to stop autonomous playback");
+    } finally {
+      setAutonomyBusy(false);
+    }
+  }, []);
+
   const searchDropdownResults = useMemo(() => {
     const deduped = new Map<string, TrackSummary>();
     [...localTracks, ...searchResults].forEach((track) => {
@@ -709,9 +736,13 @@ function App() {
                     analysis={analysis}
                     choreography={cueSummary}
                     schedule={currentSchedule}
+                    autonomy={state?.autonomy ?? { status: "idle", note: "Autonomous scheduler idle." }}
                     analysisStatus={analysisStatus}
                     analysisLoading={analysisLoading}
                     analysisError={analysisError}
+                    autonomyBusy={autonomyBusy}
+                    onStartAutonomy={() => void handleStartAutonomy()}
+                    onStopAutonomy={() => void handleStopAutonomy()}
                   />
                 </TabsContent>
               </Tabs>

--- a/frontend/src/components/analysis/track-info-panel.tsx
+++ b/frontend/src/components/analysis/track-info-panel.tsx
@@ -1,4 +1,5 @@
 import type {
+  AutonomousPerformanceState,
   AnalysisStatusResponse,
   AudioAnalysis,
   ChoreographySchedule,
@@ -7,23 +8,32 @@ import type {
 } from "@/lib/types";
 
 import { formatDate, formatDuration } from "@/lib/analysis-view";
+import { Button } from "@/components/ui/button";
 
 export function TrackInfoPanel({
   track,
   analysis,
   choreography,
   schedule,
+  autonomy,
   analysisStatus,
   analysisLoading,
   analysisError,
+  autonomyBusy,
+  onStartAutonomy,
+  onStopAutonomy,
 }: {
   track: TrackSummary | null;
   analysis: AudioAnalysis | null;
   choreography: ChoreographyTimeline | null;
   schedule: ChoreographySchedule | null;
+  autonomy: AutonomousPerformanceState;
   analysisStatus: AnalysisStatusResponse | null;
   analysisLoading: boolean;
   analysisError: string | null;
+  autonomyBusy: boolean;
+  onStartAutonomy: () => void;
+  onStopAutonomy: () => void;
 }) {
   return (
     <div className="grid gap-6 lg:grid-cols-[0.95fr_1.05fr]">
@@ -70,6 +80,18 @@ export function TrackInfoPanel({
                 : "The phrase scheduler appears after analysis is available for the selected track."
             }
           />
+          <Banner
+            title={`Autonomy ${autonomy.status}`}
+            note={autonomy.note ?? "Autonomous playback is idle."}
+          />
+          <div className="flex flex-wrap gap-3">
+            <Button disabled={!schedule || autonomyBusy} onClick={onStartAutonomy}>
+              {autonomyBusy ? "Starting..." : "Start Autonomous"}
+            </Button>
+            <Button variant="ghost" disabled={autonomyBusy || autonomy.status === "idle"} onClick={onStopAutonomy}>
+              Stop Autonomous
+            </Button>
+          </div>
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
             <InfoTile label="Sample Rate" value={analysis ? `${analysis.sample_rate} Hz` : "--"} />
             <InfoTile label="Waveform Buckets" value={analysis ? `${analysis.waveform.bucket_count}` : "--"} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -135,6 +135,18 @@ export function stopMovement() {
   });
 }
 
+export function startAutonomy() {
+  return request<RobotState>("/api/autonomy/start", {
+    method: "POST",
+  });
+}
+
+export function stopAutonomy() {
+  return request<RobotState>("/api/autonomy/stop", {
+    method: "POST",
+  });
+}
+
 export function setMode(mode: DanceMode) {
   return request<RobotState>("/api/mode", {
     method: "POST",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -11,6 +11,7 @@ export type ArmChannel = "left" | "right";
 export type ExecutionMode = "mirror" | "unison" | "call_response" | "asymmetric";
 export type MovementStatus = "idle" | "running" | "completed" | "stopped" | "error";
 export type MovementTargetScope = "single" | "both";
+export type AutonomyStatus = "idle" | "armed" | "running" | "error";
 export type ArmVerificationStatus =
   | "idle"
   | "ready"
@@ -132,6 +133,15 @@ export interface ChoreographySchedule {
   generated_at: string;
   phrase_count: number;
   phrases: ScheduledMovementPhrase[];
+}
+
+export interface AutonomousPerformanceState {
+  status: AutonomyStatus;
+  active_phrase_id?: string | null;
+  current_phrase?: ScheduledMovementPhrase | null;
+  next_phrase_id?: string | null;
+  note?: string | null;
+  last_transition_at?: string | null;
 }
 
 export interface AudioAnalysis {
@@ -353,4 +363,5 @@ export interface RobotState {
   dual_arm: DualArmState;
   movement_library: MovementLibraryState;
   schedule?: ChoreographySchedule | null;
+  autonomy: AutonomousPerformanceState;
 }


### PR DESCRIPTION
Closes #57

## Summary
- add autonomous scheduler start/stop endpoints and state
- trigger scheduled movement phrases from transport time during autonomous mode
- expose autonomous controls and status in the track info panel

## Verification
- python3 -m compileall backend/app
- backend/.venv/bin/python -m unittest discover -s backend/tests -v
- npm run build