### PR TITLE
feat: add schedule style controls and phrase mapping

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,8 @@ from .models import (
     PulseUpdate,
     RobotConfig,
     RobotState,
+    ScheduleConfigUpdate,
+    SchedulePhraseUpdate,
     SceneUpdate,
     ServoUpdate,
     TrackReference,
@@ -340,3 +342,24 @@ def get_schedule(source: TrackSource, track_id: str) -> ChoreographySchedule:
         raise HTTPException(status_code=409, detail=f"Schedule is waiting on analysis: {status.status}")
 
     raise HTTPException(status_code=404, detail="Schedule is not available yet")
+
+
+@app.post("/api/schedule/{source}/{track_id}/config", response_model=RobotState)
+def update_schedule_config(source: TrackSource, track_id: str, payload: ScheduleConfigUpdate) -> RobotState:
+    try:
+        return store.update_schedule_config(TrackReference(track_id=track_id, source=source), payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/api/schedule/{source}/{track_id}/phrases/{phrase_id}", response_model=RobotState)
+def update_schedule_phrase(
+    source: TrackSource,
+    track_id: str,
+    phrase_id: str,
+    payload: SchedulePhraseUpdate,
+) -> RobotState:
+    try:
+        return store.update_schedule_phrase(TrackReference(track_id=track_id, source=source), phrase_id, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -330,10 +330,35 @@ class ScheduledMovementPhrase(BaseModel):
     notes: str | None = None
 
 
+class ScheduleStylePreset(BaseModel):
+    style_id: str
+    label: str
+    summary: str
+    density_scale: float = Field(default=1.0, ge=0.5, le=2.0)
+    intensity_scale: float = Field(default=1.0, ge=0.5, le=1.5)
+
+
+class SchedulePhraseOverride(BaseModel):
+    phrase_id: str
+    movement_id: str | None = None
+    preset_id: str | None = None
+    execution_mode: ExecutionMode | None = None
+    target_scope: MovementTargetScope | None = None
+
+
+class ScheduleConfig(BaseModel):
+    style_id: str = "baseline"
+    density_scale: float = Field(default=1.0, ge=0.5, le=2.0)
+    intensity_scale: float = Field(default=1.0, ge=0.5, le=1.5)
+    phrase_overrides: list[SchedulePhraseOverride] = Field(default_factory=list)
+
+
 class ChoreographySchedule(BaseModel):
     track_id: str
     source: TrackSource
     style_id: str = "baseline"
+    config: ScheduleConfig = Field(default_factory=ScheduleConfig)
+    available_styles: list[ScheduleStylePreset] = Field(default_factory=list)
     generated_at: str
     phrase_count: int = Field(ge=0)
     phrases: list[ScheduledMovementPhrase] = Field(default_factory=list)
@@ -455,6 +480,20 @@ class TrackSelection(BaseModel):
 class TrackReference(BaseModel):
     track_id: str
     source: TrackSource
+
+
+class ScheduleConfigUpdate(BaseModel):
+    style_id: str | None = None
+    density_scale: float | None = Field(default=None, ge=0.5, le=2.0)
+    intensity_scale: float | None = Field(default=None, ge=0.5, le=1.5)
+
+
+class SchedulePhraseUpdate(BaseModel):
+    movement_id: str | None = None
+    preset_id: str | None = None
+    execution_mode: ExecutionMode | None = None
+    target_scope: MovementTargetScope | None = None
+    clear_override: bool = False
 
 
 class SongSection(BaseModel):

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -7,23 +7,68 @@ from .models import (
     ChoreographySchedule,
     ExecutionMode,
     MovementDefinition,
+    MovementTargetScope,
+    ScheduleConfig,
+    SchedulePhraseOverride,
+    ScheduleStylePreset,
     ScheduledMovementPhrase,
     SectionLabel,
 )
+
+
+STYLE_PRESETS = {
+    "baseline": ScheduleStylePreset(
+        style_id="baseline",
+        label="Baseline",
+        summary="Balanced phrase density with the default section-to-movement mapping.",
+        density_scale=1.0,
+        intensity_scale=1.0,
+    ),
+    "smooth": ScheduleStylePreset(
+        style_id="smooth",
+        label="Smooth",
+        summary="Lower density, softer phrasing, and more unison motion.",
+        density_scale=0.8,
+        intensity_scale=0.9,
+    ),
+    "groovy": ScheduleStylePreset(
+        style_id="groovy",
+        label="Groovy",
+        summary="Balanced pulse with frequent wrist-led phrases and light mirrored accents.",
+        density_scale=1.0,
+        intensity_scale=1.0,
+    ),
+    "punchy": ScheduleStylePreset(
+        style_id="punchy",
+        label="Punchy",
+        summary="Denser phrase starts with stronger mirrored accents on high-energy sections.",
+        density_scale=1.25,
+        intensity_scale=1.2,
+    ),
+    "expressive": ScheduleStylePreset(
+        style_id="expressive",
+        label="Expressive",
+        summary="Higher intensity with larger wave phrases and more visible section contrast.",
+        density_scale=1.1,
+        intensity_scale=1.15,
+    ),
+}
 
 
 class ChoreographyScheduler:
     def __init__(self, movements: list[MovementDefinition]) -> None:
         self.movements = {movement.movement_id: movement for movement in movements}
 
-    def build_schedule(self, analysis: AudioAnalysis, *, style_id: str = "baseline") -> ChoreographySchedule:
+    def build_schedule(self, analysis: AudioAnalysis, *, config: ScheduleConfig | None = None) -> ChoreographySchedule:
+        resolved_config = self._resolve_config(config)
+        style = self._style_preset(resolved_config.style_id)
         phrases: list[ScheduledMovementPhrase] = []
         downbeats = analysis.downbeats or analysis.beats
         beats = analysis.beats
         phrase_index = 0
 
         for section in analysis.sections:
-            movement_id, preset_id, execution_mode, beat_stride = self._section_plan(section)
+            movement_id, preset_id, execution_mode, beat_stride = self._section_plan(section, resolved_config, style)
             movement = self.movements.get(movement_id)
             if movement is None:
                 continue
@@ -36,39 +81,118 @@ class ChoreographyScheduler:
                     continue
                 phrases.append(
                     ScheduledMovementPhrase(
-                        phrase_id=f"{movement_id}-{phrase_index}",
+                        phrase_id=f"phrase-{phrase_index}",
                         movement_id=movement_id,
                         preset_id=preset_id,
                         start_seconds=round(start, 3),
                         end_seconds=round(end, 3),
                         section_label=section.label,
                         execution_mode=execution_mode,
-                        intensity=round(section.energy_mean, 3),
-                        density=round(section.density_mean, 3),
-                        notes=f"{section.label.value} phrase aligned to beat grid",
+                        target_scope=MovementTargetScope.BOTH,
+                        intensity=round(min(1.0, section.energy_mean * resolved_config.intensity_scale), 3),
+                        density=round(min(1.0, section.density_mean * resolved_config.density_scale), 3),
+                        notes=f"{style.label} mapping for {section.label.value}",
                     )
                 )
                 phrase_index += 1
 
+        override_map = {override.phrase_id: override for override in resolved_config.phrase_overrides}
+        phrases = [self._apply_override(phrase, override_map.get(phrase.phrase_id)) for phrase in phrases]
+
         return ChoreographySchedule(
             track_id=analysis.track_id,
             source=analysis.source,
-            style_id=style_id,
+            style_id=resolved_config.style_id,
+            config=resolved_config,
+            available_styles=list(STYLE_PRESETS.values()),
             generated_at=datetime.now(UTC).isoformat(),
             phrase_count=len(phrases),
             phrases=phrases,
         )
 
-    def _section_plan(self, section) -> tuple[str, str, ExecutionMode, int]:
+    def _resolve_config(self, config: ScheduleConfig | None) -> ScheduleConfig:
+        if config is None:
+            return ScheduleConfig()
+        style = self._style_preset(config.style_id)
+        return ScheduleConfig(
+            style_id=style.style_id,
+            density_scale=config.density_scale,
+            intensity_scale=config.intensity_scale,
+            phrase_overrides=config.phrase_overrides,
+        )
+
+    def _style_preset(self, style_id: str) -> ScheduleStylePreset:
+        return STYLE_PRESETS.get(style_id, STYLE_PRESETS["baseline"])
+
+    def _section_plan(self, section, config: ScheduleConfig, style: ScheduleStylePreset) -> tuple[str, str, ExecutionMode, int]:
+        density = max(0.5, min(2.0, style.density_scale * config.density_scale))
+        intensity = max(0.5, min(1.5, style.intensity_scale * config.intensity_scale))
+
+        if style.style_id == "smooth":
+            if section.label in {SectionLabel.INTRO, SectionLabel.OUTRO, SectionLabel.BREAK, SectionLabel.BRIDGE}:
+                return "wrist_lean", "normal", ExecutionMode.UNISON, self._stride(3, density)
+            if section.label == SectionLabel.CHORUS:
+                return "wave", "subtle", ExecutionMode.UNISON, self._stride(2, density)
+            return "wrist_lean", "normal", ExecutionMode.UNISON, self._stride(2, density)
+
+        if style.style_id == "punchy":
+            if section.label in {SectionLabel.INTRO, SectionLabel.OUTRO}:
+                return "wrist_lean", "normal", ExecutionMode.UNISON, self._stride(2, density)
+            if section.label == SectionLabel.CHORUS or section.energy_mean * intensity >= 0.62:
+                return "wave", "exaggerated", ExecutionMode.MIRROR, self._stride(1, density)
+            return "wrist_lean", "normal", ExecutionMode.MIRROR, self._stride(1, density)
+
+        if style.style_id == "expressive":
+            if section.label in {SectionLabel.INTRO, SectionLabel.BREAK, SectionLabel.OUTRO}:
+                return "wrist_lean", "normal", ExecutionMode.UNISON, self._stride(2, density)
+            if section.label in {SectionLabel.CHORUS, SectionLabel.BRIDGE}:
+                return "wave", "exaggerated", ExecutionMode.MIRROR, self._stride(1, density)
+            return "wave", "normal", ExecutionMode.UNISON, self._stride(1, density)
+
+        if style.style_id == "groovy":
+            if section.label in {SectionLabel.INTRO, SectionLabel.OUTRO, SectionLabel.BREAK}:
+                return "wrist_lean", "normal", ExecutionMode.UNISON, self._stride(2, density)
+            if section.label == SectionLabel.CHORUS:
+                return "wave", "normal", ExecutionMode.MIRROR, self._stride(1, density)
+            return "wrist_lean", "normal", ExecutionMode.MIRROR if section.energy_mean * intensity > 0.58 else ExecutionMode.UNISON, self._stride(1, density)
+
         if section.label in {SectionLabel.INTRO, SectionLabel.OUTRO, SectionLabel.BREAK}:
-            return "wrist_lean", "normal", ExecutionMode.UNISON, 2
+            return "wrist_lean", "normal", ExecutionMode.UNISON, self._stride(2, density)
         if section.label == SectionLabel.CHORUS:
-            return "wave", "exaggerated", ExecutionMode.MIRROR, 1
+            return "wave", "exaggerated", ExecutionMode.MIRROR, self._stride(1, density)
         if section.label == SectionLabel.BRIDGE:
-            return "wave", "subtle", ExecutionMode.UNISON, 2
-        if section.energy_mean >= 0.6:
-            return "wave", "normal", ExecutionMode.MIRROR, 1
-        return "wrist_lean", "normal", ExecutionMode.UNISON, 2
+            return "wave", "subtle", ExecutionMode.UNISON, self._stride(2, density)
+        if section.energy_mean * intensity >= 0.6:
+            return "wave", "normal", ExecutionMode.MIRROR, self._stride(1, density)
+        return "wrist_lean", "normal", ExecutionMode.UNISON, self._stride(2, density)
+
+    def _stride(self, base_stride: int, density: float) -> int:
+        adjusted = round(base_stride / max(density, 0.5))
+        return max(1, adjusted)
+
+    def _apply_override(
+        self,
+        phrase: ScheduledMovementPhrase,
+        override: SchedulePhraseOverride | None,
+    ) -> ScheduledMovementPhrase:
+        if override is None:
+            return phrase
+        movement_id = override.movement_id or phrase.movement_id
+        movement = self.movements.get(movement_id)
+        preset_id = override.preset_id or phrase.preset_id
+        if movement is not None:
+            available_presets = {preset.preset_id for preset in movement.presets}
+            if preset_id not in available_presets:
+                preset_id = movement.default_preset_id or movement.presets[0].preset_id
+        return phrase.model_copy(
+            update={
+                "movement_id": movement_id,
+                "preset_id": preset_id,
+                "execution_mode": override.execution_mode or phrase.execution_mode,
+                "target_scope": override.target_scope or phrase.target_scope,
+                "notes": f"{phrase.notes}; override applied" if phrase.notes else "Override applied",
+            }
+        )
 
     def _phrase_starts_for_section(
         self,

--- a/backend/app/state.py
+++ b/backend/app/state.py
@@ -29,10 +29,14 @@ from .models import (
     PulseUpdate,
     RobotConfig,
     RobotState,
+    ScheduleConfig,
+    ScheduleConfigUpdate,
+    SchedulePhraseOverride,
+    SchedulePhraseUpdate,
     SceneName,
     ServoState,
-    SymmetryRole,
     ServoUpdate,
+    SymmetryRole,
     TrackReference,
     TrackSummary,
     TrackSelection,
@@ -119,6 +123,7 @@ class RobotStateStore:
         self.analysis_results: dict[tuple[TrackSource, str], AudioAnalysis] = {}
         self.choreography_results: dict[tuple[TrackSource, str], ChoreographyTimeline] = {}
         self.schedule_results: dict[tuple[TrackSource, str], ChoreographySchedule] = {}
+        self.schedule_configs: dict[tuple[TrackSource, str], ScheduleConfig] = {}
         self.scheduler = ChoreographyScheduler(list_movements())
         self.servos = [
             ServoRuntime(id=servo_id, name=name, angle=0.0, target_angle=0.0)
@@ -537,6 +542,42 @@ class RobotStateStore:
         self._status_for_reference(payload)
         return self.schedule_results.get(self._track_key(payload.source, payload.track_id))
 
+    def update_schedule_config(self, payload: TrackReference, update: ScheduleConfigUpdate) -> RobotState:
+        key = self._track_key(payload.source, payload.track_id)
+        existing = self.schedule_configs.get(key, ScheduleConfig())
+        next_config = existing.model_copy(
+            update={
+                "style_id": update.style_id or existing.style_id,
+                "density_scale": update.density_scale if update.density_scale is not None else existing.density_scale,
+                "intensity_scale": update.intensity_scale if update.intensity_scale is not None else existing.intensity_scale,
+            }
+        )
+        self.schedule_configs[key] = next_config
+        self._rebuild_schedule_for_reference(payload, note="Schedule style updated.")
+        return self.snapshot()
+
+    def update_schedule_phrase(self, payload: TrackReference, phrase_id: str, update: SchedulePhraseUpdate) -> RobotState:
+        key = self._track_key(payload.source, payload.track_id)
+        existing = self.schedule_configs.get(key, ScheduleConfig())
+        overrides = {override.phrase_id: override for override in existing.phrase_overrides}
+
+        if update.clear_override:
+            overrides.pop(phrase_id, None)
+        else:
+            current = overrides.get(phrase_id, SchedulePhraseOverride(phrase_id=phrase_id))
+            overrides[phrase_id] = current.model_copy(
+                update={
+                    "movement_id": update.movement_id if update.movement_id is not None else current.movement_id,
+                    "preset_id": update.preset_id if update.preset_id is not None else current.preset_id,
+                    "execution_mode": update.execution_mode if update.execution_mode is not None else current.execution_mode,
+                    "target_scope": update.target_scope if update.target_scope is not None else current.target_scope,
+                }
+            )
+
+        self.schedule_configs[key] = existing.model_copy(update={"phrase_overrides": list(overrides.values())})
+        self._rebuild_schedule_for_reference(payload, note="Phrase mapping updated.")
+        return self.snapshot()
+
     def remember_track(self, track: TrackSummary) -> TrackSummary:
         self.known_tracks[self._track_key(track.source, track.track_id)] = track
         return track
@@ -564,7 +605,7 @@ class RobotStateStore:
         key = self._track_key(analysis.source, analysis.track_id)
         self.analysis_results[key] = analysis
         self.choreography_results[key] = analysis.choreography
-        self.schedule_results[key] = self.scheduler.build_schedule(analysis)
+        self.schedule_results[key] = self.scheduler.build_schedule(analysis, config=self.schedule_configs.get(key))
 
         known_track = self.known_tracks.get(key)
         if known_track is not None:
@@ -608,6 +649,20 @@ class RobotStateStore:
         if not analysis.energy.rms:
             return 0.0
         return sum(analysis.energy.rms) / len(analysis.energy.rms)
+
+    def _rebuild_schedule_for_reference(self, payload: TrackReference, note: str) -> None:
+        key = self._track_key(payload.source, payload.track_id)
+        analysis = self.analysis_results.get(key)
+        if analysis is None:
+            raise ValueError("Audio analysis is required before editing the schedule.")
+        self.schedule_results[key] = self.scheduler.build_schedule(analysis, config=self.schedule_configs.get(key))
+        current_track = self.transport.current_track
+        if current_track and current_track.track_id == payload.track_id and current_track.source == payload.source:
+            if self.mode == DanceMode.AUTONOMOUS:
+                self.arm_adapter.stop_movement()
+                self.transport.playing = False
+                self.mode = DanceMode.IDLE
+            self._clear_autonomy_state(note)
 
     def _sync_transport_from_analysis(self, analysis: AudioAnalysis | None) -> None:
         if analysis is None:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -204,6 +204,32 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertEqual(schedule_payload["phrase_count"], len(schedule_payload["phrases"]))
         self.assertTrue(all(phrase["target_scope"] == "both" for phrase in schedule_payload["phrases"]))
         self.assertTrue(all(phrase["execution_mode"] in {"mirror", "unison"} for phrase in schedule_payload["phrases"]))
+        self.assertEqual(schedule_payload["style_id"], "baseline")
+
+        style_update = self.client.post(
+            f"/api/schedule/{track['source']}/{track['track_id']}/config",
+            json={"style_id": "punchy", "density_scale": 1.15, "intensity_scale": 1.1},
+        )
+        self.assertEqual(style_update.status_code, 200)
+        updated_schedule = style_update.json()["schedule"]
+        self.assertEqual(updated_schedule["style_id"], "punchy")
+        self.assertEqual(updated_schedule["config"]["style_id"], "punchy")
+        self.assertAlmostEqual(updated_schedule["config"]["density_scale"], 1.15)
+        self.assertAlmostEqual(updated_schedule["config"]["intensity_scale"], 1.1)
+
+        first_phrase = updated_schedule["phrases"][0]
+        override_movement = "wrist_lean" if first_phrase["movement_id"] == "wave" else "wave"
+        override_preset = "normal" if override_movement == "wrist_lean" else "subtle"
+        phrase_update = self.client.post(
+            f"/api/schedule/{track['source']}/{track['track_id']}/phrases/{first_phrase['phrase_id']}",
+            json={"movement_id": override_movement, "preset_id": override_preset, "execution_mode": "unison"},
+        )
+        self.assertEqual(phrase_update.status_code, 200)
+        phrase_schedule = phrase_update.json()["schedule"]
+        remapped_phrase = next(phrase for phrase in phrase_schedule["phrases"] if phrase["phrase_id"] == first_phrase["phrase_id"])
+        self.assertEqual(remapped_phrase["movement_id"], override_movement)
+        self.assertEqual(remapped_phrase["preset_id"], override_preset)
+        self.assertEqual(remapped_phrase["execution_mode"], "unison")
 
         arms = self.client.get("/api/arms")
         self.assertEqual(arms.status_code, 200)

--- a/docs/IMPLEMENTATION_TRACKER.md
+++ b/docs/IMPLEMENTATION_TRACKER.md
@@ -31,11 +31,11 @@ The delivery sequence is:
 - `#33` Run synchronized dual-arm choreography playback on leader + follower [done]
 - `#52` Add follow-through motion layer for live movements [done]
 - `#55` Build choreography scheduler from audio analysis to movement execution [done]
-- `#57` Run autonomous music-driven dual-arm playback from the scheduler
+- `#57` Run autonomous music-driven dual-arm playback from the scheduler [done]
 - `#56` Add song-level dance style controls and phrase mapping UI
 
 ## Current Status
-- Current PR target: `#57`
+- Current PR target: `#56`
 - Current backend state:
   - Search and track selection exist
   - Local upload and persistent local track metadata are available
@@ -55,6 +55,7 @@ The delivery sequence is:
   - `#52` adds a follow-through layer on top of oscillator motions so distal joints can react with tunable delay, gain, damping, and settling
   - `#55` now adds a beat-aligned scheduler that converts analysis sections and beat grids into timed movement phrases
   - `#57` now adds autonomous playback controls that arm the transport, trigger scheduled phrases on time, and stop cleanly when the schedule completes or is cancelled
+  - `#56` now adds editable song-level schedule style controls plus per-phrase movement remapping on top of the generated scheduler output
 - Current frontend state:
   - Home page is music-first
   - Search/select flow exists
@@ -70,7 +71,8 @@ The delivery sequence is:
   - `#52` extends movement presets and UI tuning with follow-through controls so fluidity can be tuned before live execution
   - `#45` adds terminal scripts for record/replay/fitting so manual observations can drive later motion refinement outside the UI
   - `#55` lets the app inspect scheduled phrase output for the selected track
-  - `#57` is now wiring autonomous transport control so scheduled phrases execute live on one or both arms from the Track Info page
+  - `#57` now runs scheduled phrases live on one or both arms from the Track Info page
+  - `#56` is now adding song-level style controls and phrase remapping directly inside the analysis views
 
 ## Workflow Rule
 - Each ticket must ship from a feature branch through a pull request.
@@ -86,8 +88,7 @@ The delivery sequence is:
 - Persist computed audio analysis under `.data/analysis-cache/json/` and remote source audio under `.data/analysis-cache/audio/`.
 
 ## PR Order
-1. `#57` Autonomous dual-arm playback from the scheduler
-2. `#56` Song-level style controls and phrase mapping UI
+1. `#56` Song-level style controls and phrase mapping UI
 
 ## Update Rule
 After each merged PR:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import {
   moveArmsToNeutral,
   resetArmState,
   runMovement,
+  updateScheduleConfig,
+  updateSchedulePhrase,
   resetEmergencyStop,
   searchTracks,
   setArmConnection,
@@ -32,6 +34,7 @@ import type {
   MovementDefinition,
   MovementTargetScope,
   RobotState,
+  ScheduleConfig,
   TrackSummary,
 } from "@/lib/types";
 import { RhythmPanel } from "@/components/analysis/rhythm-panel";
@@ -61,6 +64,12 @@ type MovementTuning = {
   followThroughGain: number;
   followThroughDamping: number;
   followThroughSettle: number;
+};
+
+type ScheduleDraft = {
+  style_id: string;
+  density_scale: number;
+  intensity_scale: number;
 };
 
 function defaultMovementTuning(movement: MovementDefinition): MovementTuning {
@@ -114,6 +123,8 @@ function App() {
   const [movementBusyAction, setMovementBusyAction] = useState<string | null>(null);
   const [autonomyBusy, setAutonomyBusy] = useState(false);
   const [movementTunings, setMovementTunings] = useState<Record<string, MovementTuning>>({});
+  const [scheduleDraft, setScheduleDraft] = useState<ScheduleDraft | null>(null);
+  const [scheduleBusyAction, setScheduleBusyAction] = useState<string | null>(null);
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
 
   const refreshState = async () => {
@@ -223,6 +234,19 @@ function App() {
   const currentTrack = state?.transport.current_track ?? null;
   const currentSchedule = state?.schedule ?? null;
   const movementLibrary = state?.movement_library ?? null;
+
+  useEffect(() => {
+    const config: ScheduleConfig | undefined | null = currentSchedule?.config;
+    if (!config) {
+      setScheduleDraft(null);
+      return;
+    }
+    setScheduleDraft({
+      style_id: config.style_id,
+      density_scale: config.density_scale,
+      intensity_scale: config.intensity_scale,
+    });
+  }, [currentSchedule?.track_id, currentSchedule?.source, currentSchedule?.style_id, currentSchedule?.generated_at]);
 
   useEffect(() => {
     if (!currentTrack) {
@@ -557,6 +581,63 @@ function App() {
     }
   }, []);
 
+  const handleApplyScheduleStyle = useCallback(async () => {
+    if (!currentTrack || !scheduleDraft) {
+      return;
+    }
+    setScheduleBusyAction("apply-style");
+    try {
+      await commitAction(() =>
+        updateScheduleConfig(currentTrack.track_id, currentTrack.source, {
+          style_id: scheduleDraft.style_id,
+          density_scale: scheduleDraft.density_scale,
+          intensity_scale: scheduleDraft.intensity_scale,
+        }),
+      );
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to update schedule style");
+    } finally {
+      setScheduleBusyAction(null);
+    }
+  }, [currentTrack, scheduleDraft]);
+
+  const handleResetScheduleStyle = useCallback(() => {
+    if (!currentSchedule) {
+      return;
+    }
+    setScheduleDraft({
+      style_id: currentSchedule.config.style_id,
+      density_scale: currentSchedule.config.density_scale,
+      intensity_scale: currentSchedule.config.intensity_scale,
+    });
+  }, [currentSchedule]);
+
+  const handlePhraseMappingChange = useCallback(
+    async (
+      phraseId: string,
+      payload: {
+        movement_id?: string;
+        preset_id?: string;
+        execution_mode?: ExecutionMode;
+      },
+    ) => {
+      if (!currentTrack) {
+        return;
+      }
+      setScheduleBusyAction(`phrase:${phraseId}`);
+      try {
+        await commitAction(() => updateSchedulePhrase(currentTrack.track_id, currentTrack.source, phraseId, payload));
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unable to update phrase mapping");
+      } finally {
+        setScheduleBusyAction(null);
+      }
+    },
+    [currentTrack],
+  );
+
   const searchDropdownResults = useMemo(() => {
     const deduped = new Map<string, TrackSummary>();
     [...localTracks, ...searchResults].forEach((track) => {
@@ -727,7 +808,14 @@ function App() {
                 </TabsContent>
 
                 <TabsContent value="structure" className="pt-6">
-                  <StructurePanel analysis={analysis} choreography={cueSummary} schedule={currentSchedule} />
+                  <StructurePanel
+                    analysis={analysis}
+                    choreography={cueSummary}
+                    schedule={currentSchedule}
+                    movementLibrary={movementLibrary}
+                    busyAction={scheduleBusyAction}
+                    onPhraseMappingChange={(phraseId, payload) => void handlePhraseMappingChange(phraseId, payload)}
+                  />
                 </TabsContent>
 
                 <TabsContent value="track-info" className="pt-6">
@@ -740,6 +828,31 @@ function App() {
                     analysisStatus={analysisStatus}
                     analysisLoading={analysisLoading}
                     analysisError={analysisError}
+                    scheduleDraft={scheduleDraft}
+                    scheduleBusy={scheduleBusyAction === "apply-style"}
+                    onScheduleStyleChange={(styleId) =>
+                      setScheduleDraft((current) =>
+                        current
+                          ? { ...current, style_id: styleId }
+                          : { style_id: styleId, density_scale: currentSchedule?.config.density_scale ?? 1, intensity_scale: currentSchedule?.config.intensity_scale ?? 1 },
+                      )
+                    }
+                    onScheduleDensityChange={(value) =>
+                      setScheduleDraft((current) =>
+                        current
+                          ? { ...current, density_scale: value }
+                          : { style_id: currentSchedule?.config.style_id ?? "baseline", density_scale: value, intensity_scale: currentSchedule?.config.intensity_scale ?? 1 },
+                      )
+                    }
+                    onScheduleIntensityChange={(value) =>
+                      setScheduleDraft((current) =>
+                        current
+                          ? { ...current, intensity_scale: value }
+                          : { style_id: currentSchedule?.config.style_id ?? "baseline", density_scale: currentSchedule?.config.density_scale ?? 1, intensity_scale: value },
+                      )
+                    }
+                    onApplyScheduleStyle={() => void handleApplyScheduleStyle()}
+                    onResetScheduleStyle={handleResetScheduleStyle}
                     autonomyBusy={autonomyBusy}
                     onStartAutonomy={() => void handleStartAutonomy()}
                     onStopAutonomy={() => void handleStopAutonomy()}

--- a/frontend/src/components/analysis/structure-panel.tsx
+++ b/frontend/src/components/analysis/structure-panel.tsx
@@ -1,6 +1,13 @@
-import type { AudioAnalysis, ChoreographySchedule, ChoreographyTimeline } from "@/lib/types";
+import type {
+  AudioAnalysis,
+  ChoreographySchedule,
+  ChoreographyTimeline,
+  ExecutionMode,
+  MovementLibraryState,
+} from "@/lib/types";
 
 import { formatDuration } from "@/lib/analysis-view";
+import { Button } from "@/components/ui/button";
 
 function cueCountInWindow(times: number[], start: number, end: number) {
   return times.filter((time) => time >= start && time < end).length;
@@ -10,10 +17,23 @@ export function StructurePanel({
   analysis,
   choreography,
   schedule,
+  movementLibrary,
+  busyAction,
+  onPhraseMappingChange,
 }: {
   analysis: AudioAnalysis | null;
   choreography: ChoreographyTimeline | null;
   schedule: ChoreographySchedule | null;
+  movementLibrary: MovementLibraryState | null;
+  busyAction: string | null;
+  onPhraseMappingChange: (
+    phraseId: string,
+    payload: {
+      movement_id?: string;
+      preset_id?: string;
+      execution_mode?: ExecutionMode;
+    },
+  ) => void;
 }) {
   if (!analysis) {
     return <EmptyPanel text="Structure markers show up after the backend returns a section timeline." />;
@@ -94,9 +114,15 @@ export function StructurePanel({
           />
           {schedule ? (
             <div className="rounded-[24px] border border-white/10 bg-white/[0.04] p-4">
-              <p className="text-base font-semibold text-white">First Scheduled Phrases</p>
+              <p className="text-base font-semibold text-white">Phrase Mapping</p>
+              <p className="mt-2 text-sm text-slate-400">
+                Override movement, preset, or execution mode for each phrase window. Changes are saved back into the scheduler output.
+              </p>
               <div className="mt-4 space-y-3">
-                {schedule.phrases.slice(0, 4).map((phrase) => (
+                {schedule.phrases.slice(0, 8).map((phrase) => {
+                  const movement = movementLibrary?.movements.find((entry) => entry.movement_id === phrase.movement_id) ?? null;
+                  const phraseBusy = busyAction === `phrase:${phrase.phrase_id}`;
+                  return (
                   <div key={phrase.phrase_id} className="rounded-[18px] border border-white/10 bg-black/20 px-4 py-3">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <p className="text-sm font-semibold capitalize text-white">
@@ -109,8 +135,62 @@ export function StructurePanel({
                     <p className="mt-2 text-xs text-slate-400">
                       {phrase.section_label} · {phrase.execution_mode} · intensity {Math.round(phrase.intensity * 100)}%
                     </p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {movementLibrary?.movements.map((entry) => (
+                        <button
+                          key={`${phrase.phrase_id}-${entry.movement_id}`}
+                          type="button"
+                          onClick={() => onPhraseMappingChange(phrase.phrase_id, { movement_id: entry.movement_id })}
+                          className={`rounded-full border px-3 py-1 text-xs transition ${
+                            phrase.movement_id === entry.movement_id
+                              ? "border-primary bg-primary/20 text-white"
+                              : "border-white/10 bg-white/[0.03] text-slate-300 hover:border-primary/40 hover:text-white"
+                          }`}
+                        >
+                          {entry.name}
+                        </button>
+                      ))}
+                    </div>
+                    {movement ? (
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {movement.presets.map((preset) => (
+                          <button
+                            key={`${phrase.phrase_id}-${preset.preset_id}`}
+                            type="button"
+                            onClick={() => onPhraseMappingChange(phrase.phrase_id, { movement_id: movement.movement_id, preset_id: preset.preset_id })}
+                            className={`rounded-full border px-3 py-1 text-xs transition ${
+                              phrase.preset_id === preset.preset_id
+                                ? "border-sky-300 bg-sky-400/20 text-white"
+                                : "border-white/10 bg-white/[0.03] text-slate-300 hover:border-sky-300/40 hover:text-white"
+                            }`}
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {(["unison", "mirror"] as ExecutionMode[]).map((mode) => (
+                        <button
+                          key={`${phrase.phrase_id}-${mode}`}
+                          type="button"
+                          onClick={() => onPhraseMappingChange(phrase.phrase_id, { execution_mode: mode })}
+                          className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.18em] transition ${
+                            phrase.execution_mode === mode
+                              ? "border-white/40 bg-white/15 text-white"
+                              : "border-white/10 bg-white/[0.03] text-slate-300 hover:border-white/30 hover:text-white"
+                          }`}
+                        >
+                          {mode}
+                        </button>
+                      ))}
+                      <Button type="button" variant="ghost" size="sm" disabled>
+                        {phraseBusy ? "Saving..." : "Mapped"}
+                      </Button>
+                    </div>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           ) : null}

--- a/frontend/src/components/analysis/track-info-panel.tsx
+++ b/frontend/src/components/analysis/track-info-panel.tsx
@@ -4,11 +4,13 @@ import type {
   AudioAnalysis,
   ChoreographySchedule,
   ChoreographyTimeline,
+  ScheduleConfig,
   TrackSummary,
 } from "@/lib/types";
 
 import { formatDate, formatDuration } from "@/lib/analysis-view";
 import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
 
 export function TrackInfoPanel({
   track,
@@ -19,6 +21,13 @@ export function TrackInfoPanel({
   analysisStatus,
   analysisLoading,
   analysisError,
+  scheduleDraft,
+  scheduleBusy,
+  onScheduleStyleChange,
+  onScheduleDensityChange,
+  onScheduleIntensityChange,
+  onApplyScheduleStyle,
+  onResetScheduleStyle,
   autonomyBusy,
   onStartAutonomy,
   onStopAutonomy,
@@ -31,10 +40,25 @@ export function TrackInfoPanel({
   analysisStatus: AnalysisStatusResponse | null;
   analysisLoading: boolean;
   analysisError: string | null;
+  scheduleDraft: ScheduleConfig | { style_id: string; density_scale: number; intensity_scale: number } | null;
+  scheduleBusy: boolean;
+  onScheduleStyleChange: (styleId: string) => void;
+  onScheduleDensityChange: (value: number) => void;
+  onScheduleIntensityChange: (value: number) => void;
+  onApplyScheduleStyle: () => void;
+  onResetScheduleStyle: () => void;
   autonomyBusy: boolean;
   onStartAutonomy: () => void;
   onStopAutonomy: () => void;
 }) {
+  const styles = schedule?.available_styles ?? [];
+  const styleChanged =
+    !!scheduleDraft &&
+    !!schedule &&
+    (scheduleDraft.style_id !== schedule.config.style_id ||
+      Math.abs(scheduleDraft.density_scale - schedule.config.density_scale) > 0.001 ||
+      Math.abs(scheduleDraft.intensity_scale - schedule.config.intensity_scale) > 0.001);
+
   return (
     <div className="grid gap-6 lg:grid-cols-[0.95fr_1.05fr]">
       <div className="rounded-[30px] border border-white/10 bg-black/25 p-6">
@@ -80,6 +104,65 @@ export function TrackInfoPanel({
                 : "The phrase scheduler appears after analysis is available for the selected track."
             }
           />
+          {schedule ? (
+            <div className="rounded-[24px] border border-white/10 bg-white/[0.04] p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-base font-semibold text-white">Song Style</p>
+                  <p className="mt-2 text-sm text-slate-400">
+                    Pick a song-wide dance character, then shape how dense and intense the scheduler should feel.
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <Button variant="ghost" disabled={!styleChanged || scheduleBusy} onClick={onResetScheduleStyle}>
+                    Reset
+                  </Button>
+                  <Button disabled={!styleChanged || scheduleBusy} onClick={onApplyScheduleStyle}>
+                    {scheduleBusy ? "Applying..." : "Apply Style"}
+                  </Button>
+                </div>
+              </div>
+
+              <div className="mt-5 flex flex-wrap gap-2">
+                {styles.map((style) => {
+                  const active = scheduleDraft?.style_id === style.style_id;
+                  return (
+                    <button
+                      key={style.style_id}
+                      type="button"
+                      onClick={() => onScheduleStyleChange(style.style_id)}
+                      className={`rounded-full border px-4 py-2 text-sm transition ${
+                        active
+                          ? "border-primary bg-primary/20 text-white"
+                          : "border-white/10 bg-black/20 text-slate-300 hover:border-primary/40 hover:text-white"
+                      }`}
+                    >
+                      {style.label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="mt-5 grid gap-5 md:grid-cols-2">
+                <StyleSlider
+                  label="Phrase Density"
+                  value={scheduleDraft?.density_scale ?? schedule.config.density_scale}
+                  min={0.5}
+                  max={2}
+                  step={0.05}
+                  onChange={onScheduleDensityChange}
+                />
+                <StyleSlider
+                  label="Phrase Intensity"
+                  value={scheduleDraft?.intensity_scale ?? schedule.config.intensity_scale}
+                  min={0.5}
+                  max={1.5}
+                  step={0.05}
+                  onChange={onScheduleIntensityChange}
+                />
+              </div>
+            </div>
+          ) : null}
           <Banner
             title={`Autonomy ${autonomy.status}`}
             note={autonomy.note ?? "Autonomous playback is idle."}
@@ -127,6 +210,32 @@ function InfoTile({ label, value }: { label: string; value: string }) {
     <div className="rounded-[22px] border border-white/10 bg-white/[0.04] p-4">
       <p className="hud-label">{label}</p>
       <p className="mt-3 text-xl font-semibold text-white">{value}</p>
+    </div>
+  );
+}
+
+function StyleSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <div className="rounded-[20px] border border-white/10 bg-black/20 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-medium text-white">{label}</p>
+        <span className="text-sm text-slate-400">{value.toFixed(2)}</span>
+      </div>
+      <Slider className="mt-4" value={[value]} min={min} max={max} step={step} onValueChange={([next]) => onChange(next ?? value)} />
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -243,3 +243,36 @@ export function fetchChoreography(trackId: string, source: TrackSource) {
 export function fetchSchedule(trackId: string, source: TrackSource) {
   return request<ChoreographySchedule>(`/api/schedule/${source}/${trackId}`);
 }
+
+export function updateScheduleConfig(
+  trackId: string,
+  source: TrackSource,
+  payload: {
+    style_id?: string;
+    density_scale?: number;
+    intensity_scale?: number;
+  },
+) {
+  return request<RobotState>(`/api/schedule/${source}/${trackId}/config`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function updateSchedulePhrase(
+  trackId: string,
+  source: TrackSource,
+  phraseId: string,
+  payload: {
+    movement_id?: string;
+    preset_id?: string;
+    execution_mode?: "mirror" | "unison" | "call_response" | "asymmetric";
+    target_scope?: "single" | "both";
+    clear_override?: boolean;
+  },
+) {
+  return request<RobotState>(`/api/schedule/${source}/${trackId}/phrases/${phraseId}`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -126,10 +126,35 @@ export interface ScheduledMovementPhrase {
   notes?: string | null;
 }
 
+export interface ScheduleStylePreset {
+  style_id: string;
+  label: string;
+  summary: string;
+  density_scale: number;
+  intensity_scale: number;
+}
+
+export interface SchedulePhraseOverride {
+  phrase_id: string;
+  movement_id?: string | null;
+  preset_id?: string | null;
+  execution_mode?: ExecutionMode | null;
+  target_scope?: MovementTargetScope | null;
+}
+
+export interface ScheduleConfig {
+  style_id: string;
+  density_scale: number;
+  intensity_scale: number;
+  phrase_overrides: SchedulePhraseOverride[];
+}
+
 export interface ChoreographySchedule {
   track_id: string;
   source: TrackSource;
   style_id: string;
+  config: ScheduleConfig;
+  available_styles: ScheduleStylePreset[];
   generated_at: string;
   phrase_count: number;
   phrases: ScheduledMovementPhrase[];


### PR DESCRIPTION
Closes #56

## Summary
- add editable schedule style config and phrase override endpoints
- make scheduler output respond to song-wide style, density, and intensity tuning
- add analysis UI controls for style presets and per-phrase movement remapping

## Verification
- python3 -m compileall backend/app
- backend/.venv/bin/python -m unittest discover -s backend/tests -v
- npm run build