### PR TITLE
fix: unify performance transport sync

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -403,6 +403,7 @@ class TransportUpdate(BaseModel):
     bpm: float = Field(ge=40, le=220)
     energy: float = Field(ge=0.0, le=1.0)
     playing: bool = True
+    position_seconds: float | None = Field(default=None, ge=0.0)
 
 
 class SceneUpdate(BaseModel):

--- a/backend/app/state.py
+++ b/backend/app/state.py
@@ -117,6 +117,7 @@ class RobotStateStore:
         self.sync_quality = 92
         self.started_at = monotonic()
         self.last_tick = monotonic()
+        self.last_external_transport_sync = 0.0
         self.scene = SceneName.IDLE
         self.known_tracks: dict[tuple[TrackSource, str], TrackSummary] = {}
         self.analysis_statuses: dict[tuple[TrackSource, str], AnalysisStatusResponse] = {}
@@ -148,14 +149,19 @@ class RobotStateStore:
             self.transport.playing = False
             self.mode = DanceMode.IDLE
 
-        if self.transport.playing:
+        external_clock_recent = (
+            self.transport.current_track is not None
+            and (now - self.last_external_transport_sync) < 0.6
+        )
+
+        if self.transport.playing and not external_clock_recent:
             self.transport.position_seconds += delta
 
         analysis = self.current_analysis()
         choreography = self.current_choreography()
         schedule = self.current_schedule()
         self._sync_transport_from_analysis(analysis)
-        if self.mode == DanceMode.AUTONOMOUS:
+        if self.mode == DanceMode.AUTONOMOUS and self.transport.playing:
             self._tick_autonomous_schedule(schedule, analysis.duration_seconds if analysis is not None else None)
 
         beat = self.transport.position_seconds * max(self.transport.bpm, 1) / 60.0
@@ -305,9 +311,28 @@ class RobotStateStore:
         self.transport.track_name = payload.track_name
         self.transport.bpm = max(40, min(220, int(round(payload.bpm))))
         self.transport.energy = max(0.0, min(1.0, payload.energy))
-        self.transport.playing = False if self.arm_adapter.emergency_stop_active() else payload.playing
+        if payload.position_seconds is not None:
+            self.transport.position_seconds = payload.position_seconds
+            self.last_external_transport_sync = monotonic()
+        requested_playing = False if self.arm_adapter.emergency_stop_active() else payload.playing
+        was_playing = self.transport.playing
+        self.transport.playing = requested_playing
         if self.transport.playing and self.mode == DanceMode.IDLE:
             self.mode = DanceMode.AUTONOMOUS
+        if self.mode == DanceMode.AUTONOMOUS:
+            if was_playing and not self.transport.playing:
+                self.arm_adapter.stop_movement()
+                self.autonomy.status = AutonomyStatus.ARMED
+                self.autonomy.active_phrase_id = None
+                self.autonomy.current_phrase = None
+                self.autonomy.note = "Autonomous playback paused with the song transport."
+                self.autonomy.last_transition_at = datetime.now(UTC).isoformat()
+            elif not was_playing and self.transport.playing:
+                self.autonomy.status = AutonomyStatus.ARMED
+                self.autonomy.active_phrase_id = None
+                self.autonomy.current_phrase = None
+                self.autonomy.note = "Autonomous playback resumed from the current song position."
+                self.autonomy.last_transition_at = datetime.now(UTC).isoformat()
         return self.snapshot()
 
     def apply_scene(self, scene: SceneName) -> RobotState:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -178,9 +178,42 @@ class ApiSmokeTest(unittest.TestCase):
         expected_spectrum = self._expected_spectrum_prefix(payload)
         self.assertEqual(state_payload["spectrum"][:3], expected_spectrum)
         self.assertIsNotNone(state_payload["schedule"])
-        self.assertGreater(state_payload["schedule"]["phrase_count"], 0)
-        self.assertEqual(len(state_payload["dual_arm"]["arms"]), 2)
-        self.assertEqual(state_payload["dual_arm"]["execution"]["mode"], "mirror")
+
+    def test_transport_external_clock_heartbeat_prevents_drift(self) -> None:
+        audio = self._fixture_wav()
+        upload = self.client.post("/api/tracks/upload", files={"file": ("fixture.wav", audio, "audio/wav")})
+        self.assertEqual(upload.status_code, 200)
+        track = upload.json()
+
+        select = self.client.post("/api/tracks/select", json={"track": track, "autoplay": False})
+        self.assertEqual(select.status_code, 200)
+
+        analysis_start = self.client.post(
+            "/api/analysis/start",
+            json={"track_id": track["track_id"], "source": track["source"]},
+        )
+        self.assertEqual(analysis_start.status_code, 200)
+
+        heartbeat = self.client.post(
+            "/api/transport",
+            json={
+                "track_name": f"{track['title']} - {track['artist']}",
+                "bpm": 128,
+                "energy": 0.5,
+                "playing": True,
+                "position_seconds": 12.5,
+            },
+        )
+        self.assertEqual(heartbeat.status_code, 200)
+
+        time.sleep(0.15)
+        snapshot = self.client.get("/api/state")
+        self.assertEqual(snapshot.status_code, 200)
+        snapshot_payload = snapshot.json()
+        self.assertAlmostEqual(snapshot_payload["transport"]["position_seconds"], 12.5, delta=0.25)
+        self.assertGreater(snapshot_payload["schedule"]["phrase_count"], 0)
+        self.assertEqual(len(snapshot_payload["dual_arm"]["arms"]), 2)
+        self.assertEqual(snapshot_payload["dual_arm"]["execution"]["mode"], "mirror")
 
         choreography = self.client.get(f"/api/choreography/{track['source']}/{track['track_id']}")
         self.assertEqual(choreography.status_code, 200)
@@ -478,6 +511,22 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertIsNotNone(autonomy_running)
         self.assertIn(autonomy_running["current_phrase"]["movement_id"], {"wave", "wrist_lean"})
         self.assertIn(autonomy_running["current_phrase"]["execution_mode"], {"mirror", "unison"})
+
+        paused = self.client.post(
+            "/api/transport",
+            json={
+                "track_name": state_live["transport"]["track_name"],
+                "bpm": state_live["transport"]["bpm"],
+                "energy": state_live["transport"]["energy"],
+                "playing": False,
+                "position_seconds": state_live["transport"]["position_seconds"],
+            },
+        )
+        self.assertEqual(paused.status_code, 200)
+        paused_payload = paused.json()
+        self.assertFalse(paused_payload["transport"]["playing"])
+        self.assertEqual(paused_payload["autonomy"]["status"], "armed")
+        self.assertEqual(paused_payload["movement_library"]["active"]["status"], "stopped")
 
         autonomy_stop = self.client.post("/api/autonomy/stop")
         self.assertEqual(autonomy_stop.status_code, 200)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,7 @@ import { HardwareStatusDashboard } from "@/components/hardware/hardware-status-d
 import { AppNavbar, type AppView } from "@/components/layout/app-navbar";
 import { WaveformConsole } from "@/components/music/waveform-console";
 import { MovementLibraryPage } from "@/components/movements/movement-library-page";
+import { PerformancePage } from "@/components/performance/performance-page";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -126,6 +127,16 @@ function App() {
   const [scheduleDraft, setScheduleDraft] = useState<ScheduleDraft | null>(null);
   const [scheduleBusyAction, setScheduleBusyAction] = useState<string | null>(null);
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
+  const previewPositionRef = useRef(0);
+  const previewPlayingRef = useRef(false);
+  const transportSyncInFlightRef = useRef(false);
+  const transportSyncQueuedRef = useRef<{
+    track_name: string;
+    bpm: number;
+    energy: number;
+    playing: boolean;
+    position_seconds: number;
+  } | null>(null);
 
   const refreshState = async () => {
     try {
@@ -224,16 +235,28 @@ function App() {
     };
 
     void boot();
+  }, []);
+
+  useEffect(() => {
+    const intervalMs = state?.transport.playing || state?.autonomy.status === "running" ? 250 : 1400;
     const interval = window.setInterval(() => {
       void refreshState();
-    }, 1400);
+    }, intervalMs);
 
     return () => window.clearInterval(interval);
-  }, []);
+  }, [state?.autonomy.status, state?.transport.playing]);
 
   const currentTrack = state?.transport.current_track ?? null;
   const currentSchedule = state?.schedule ?? null;
   const movementLibrary = state?.movement_library ?? null;
+
+  useEffect(() => {
+    previewPositionRef.current = previewPositionSeconds;
+  }, [previewPositionSeconds]);
+
+  useEffect(() => {
+    previewPlayingRef.current = previewPlaying;
+  }, [previewPlaying]);
 
   useEffect(() => {
     const config: ScheduleConfig | undefined | null = currentSchedule?.config;
@@ -331,38 +354,89 @@ function App() {
     };
   }, [currentTrack?.track_id, currentTrack?.source]);
 
+  useEffect(() => {
+    if (!currentTrack || activeView !== "performance") {
+      return;
+    }
+
+    const backendPosition = state?.transport.position_seconds ?? 0;
+
+    if (!previewPlayingRef.current && Math.abs(previewPositionRef.current - backendPosition) > 0.2) {
+      setPreviewPositionSeconds(backendPosition);
+    }
+
+    if (!(state?.transport.playing ?? false) && state?.autonomy.status === "idle" && backendPosition === 0 && previewPositionRef.current !== 0) {
+      setPreviewPositionSeconds(0);
+    }
+  }, [
+    activeView,
+    currentTrack,
+    state?.autonomy.status,
+    state?.transport.playing,
+    state?.transport.position_seconds,
+  ]);
+
   const bpm = analysis ? analysis.bpm : (state?.transport.bpm ?? 120);
   const energy = analysis ? average(analysis.energy.rms) : (state?.transport.energy ?? 0.5);
-  const positionSeconds = currentTrack ? previewPositionSeconds : (state?.transport.position_seconds ?? 0);
+  const positionSeconds = activeView === "performance" ? previewPositionSeconds : (state?.transport.position_seconds ?? previewPositionSeconds);
   const cueSummary = choreography ?? analysis?.choreography ?? null;
-  const transportPlaying = currentTrack ? previewPlaying : (state?.transport.playing ?? false);
+  const transportPlaying = activeView === "performance" ? previewPlaying : (state?.transport.playing ?? previewPlaying);
 
   const syncTransportPlayback = useCallback(
-    async (playing: boolean) => {
+    async (playing: boolean, nextPositionSeconds = previewPositionRef.current) => {
       if (!currentTrack) {
         setPreviewPlaying(false);
         return;
       }
 
+      const position = Math.max(0, nextPositionSeconds);
       setPreviewPlaying(playing);
+      setPreviewPositionSeconds(position);
+
+      transportSyncQueuedRef.current = {
+        track_name: `${currentTrack.title} - ${currentTrack.artist}`,
+        bpm: Math.max(40, Math.min(220, Math.round(bpm))),
+        energy: Math.max(0, Math.min(1, energy)),
+        playing,
+        position_seconds: position,
+      };
+
+      if (transportSyncInFlightRef.current) {
+        return;
+      }
+
+      transportSyncInFlightRef.current = true;
 
       try {
-        const next = await setTransport({
-          track_name: `${currentTrack.title} - ${currentTrack.artist}`,
-          bpm: Math.max(40, Math.min(220, Math.round(bpm))),
-          energy: Math.max(0, Math.min(1, energy)),
-          playing,
-        });
-        startTransition(() => {
-          setState(next);
-        });
-        setError(null);
+        while (transportSyncQueuedRef.current) {
+          const pending = transportSyncQueuedRef.current;
+          transportSyncQueuedRef.current = null;
+          const next = await setTransport(pending);
+          startTransition(() => {
+            setState(next);
+          });
+          setError(null);
+        }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Unable to update transport");
+      } finally {
+        transportSyncInFlightRef.current = false;
       }
     },
     [bpm, currentTrack, energy],
   );
+
+  useEffect(() => {
+    if (!currentTrack || !previewPlaying) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      void syncTransportPlayback(true, previewPositionRef.current);
+    }, 160);
+
+    return () => window.clearInterval(interval);
+  }, [currentTrack, previewPlaying, syncTransportPlayback]);
 
   const handleVerifyHardware = useCallback(async () => {
     setVerifyingHardware(true);
@@ -560,9 +634,12 @@ function App() {
   const handleStartAutonomy = useCallback(async () => {
     setAutonomyBusy(true);
     try {
+      setPreviewPositionSeconds(0);
+      setPreviewPlaying(true);
       await commitAction(() => startAutonomy());
       setError(null);
     } catch (err) {
+      setPreviewPlaying(false);
       setError(err instanceof Error ? err.message : "Unable to start autonomous playback");
     } finally {
       setAutonomyBusy(false);
@@ -572,6 +649,8 @@ function App() {
   const handleStopAutonomy = useCallback(async () => {
     setAutonomyBusy(true);
     try {
+      setPreviewPlaying(false);
+      setPreviewPositionSeconds(0);
       await commitAction(() => stopAutonomy());
       setError(null);
     } catch (err) {
@@ -764,6 +843,7 @@ function App() {
             <WaveformConsole
               track={currentTrack}
               analysis={analysis}
+              schedule={currentSchedule}
               currentTime={positionSeconds}
               transportPlaying={transportPlaying}
               onTimeChange={setPreviewPositionSeconds}
@@ -861,6 +941,34 @@ function App() {
               </Tabs>
             </CardContent>
           </Card>
+        ) : null}
+
+        {activeView === "performance" ? (
+          <PerformancePage
+            searchQuery={searchQuery}
+            onSearchQueryChange={setSearchQuery}
+            onSearch={() => void runSearch(searchQuery)}
+            searching={searching}
+            searchError={searchError}
+            results={searchDropdownResults}
+            currentTrack={currentTrack}
+            analysis={analysis}
+            analysisStatus={analysisStatus}
+            schedule={currentSchedule}
+            autonomy={state?.autonomy ?? { status: "idle", note: "Autonomous scheduler idle." }}
+            autonomyBusy={autonomyBusy}
+            currentTime={positionSeconds}
+            transportPlaying={transportPlaying}
+            onTimeChange={setPreviewPositionSeconds}
+            onTransportChange={syncTransportPlayback}
+            onSelectTrack={(track) => {
+              setSearchQuery(track.title);
+              setSearchResults([]);
+              void commitAction(() => selectTrack(track, true));
+            }}
+            onStartAutonomy={() => void handleStartAutonomy()}
+            onStopAutonomy={() => void handleStopAutonomy()}
+          />
         ) : null}
 
         {activeView === "movements" ? (

--- a/frontend/src/components/layout/app-navbar.tsx
+++ b/frontend/src/components/layout/app-navbar.tsx
@@ -4,10 +4,11 @@ import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
-export type AppView = "home" | "analysis" | "movements" | "robot";
+export type AppView = "home" | "performance" | "analysis" | "movements" | "robot";
 
 const NAV_ITEMS: Array<{ id: AppView; label: string }> = [
   { id: "home", label: "Home" },
+  { id: "performance", label: "Performance" },
   { id: "analysis", label: "Audio Stats" },
   { id: "movements", label: "Movement Library" },
   { id: "robot", label: "Robot Dashboard" },

--- a/frontend/src/components/music/waveform-console.tsx
+++ b/frontend/src/components/music/waveform-console.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import WaveSurfer from "wavesurfer.js";
 import { Pause, Play, Square, Waves } from "lucide-react";
 
-import type { AudioAnalysis, SongSection, TrackSummary } from "@/lib/types";
+import type { AudioAnalysis, ChoreographySchedule, TrackSummary } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
@@ -17,14 +17,6 @@ function formatClock(value: number) {
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
 
-function activeSection(sections: SongSection[], currentTime: number) {
-  return (
-    sections.find((section) => currentTime >= section.start_seconds && currentTime < section.end_seconds) ??
-    sections[0] ??
-    null
-  );
-}
-
 function isAbortError(error: unknown) {
   if (!(error instanceof Error)) {
     return false;
@@ -36,17 +28,23 @@ function isAbortError(error: unknown) {
 export function WaveformConsole({
   track,
   analysis,
+  schedule,
   currentTime,
   transportPlaying,
   onTimeChange,
   onTransportChange,
+  mediaElement,
+  compact = false,
 }: {
   track: TrackSummary | null;
   analysis: AudioAnalysis | null;
+  schedule?: ChoreographySchedule | null;
   currentTime: number;
   transportPlaying: boolean;
   onTimeChange: (value: number) => void;
-  onTransportChange: (playing: boolean) => void;
+  onTransportChange: (playing: boolean, positionSeconds?: number) => void;
+  mediaElement?: HTMLMediaElement | null;
+  compact?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const waveSurferRef = useRef<WaveSurfer | null>(null);
@@ -68,8 +66,11 @@ export function WaveformConsole({
       return;
     }
 
+    const externalTransportClock = compact && !!mediaElement;
+
     const waveSurfer = WaveSurfer.create({
       container: containerRef.current,
+      media: mediaElement ?? undefined,
       waveColor: "rgba(87, 169, 255, 0.3)",
       progressColor: "rgba(162, 219, 255, 0.95)",
       cursorColor: "#f8fafc",
@@ -90,22 +91,24 @@ export function WaveformConsole({
       onTimeChangeRef.current(0);
     });
 
-    waveSurfer.on("timeupdate", (time) => {
-      onTimeChangeRef.current(time);
-    });
+    if (!externalTransportClock) {
+      waveSurfer.on("timeupdate", (time) => {
+        onTimeChangeRef.current(time);
+      });
 
-    waveSurfer.on("play", () => {
-      onTransportChangeRef.current(true);
-    });
+      waveSurfer.on("play", () => {
+        onTransportChangeRef.current(true, waveSurfer.getCurrentTime());
+      });
 
-    waveSurfer.on("pause", () => {
-      onTransportChangeRef.current(false);
-    });
+      waveSurfer.on("pause", () => {
+        onTransportChangeRef.current(false, waveSurfer.getCurrentTime());
+      });
 
-    waveSurfer.on("finish", () => {
-      onTimeChangeRef.current(0);
-      onTransportChangeRef.current(false);
-    });
+      waveSurfer.on("finish", () => {
+        onTimeChangeRef.current(0);
+        onTransportChangeRef.current(false, 0);
+      });
+    }
 
     waveSurfer.on("error", (error) => {
       if (isAbortError(error)) {
@@ -113,7 +116,7 @@ export function WaveformConsole({
       }
       setReady(false);
       setWaveformError(error instanceof Error ? error.message : String(error));
-      onTransportChangeRef.current(false);
+      onTransportChangeRef.current(false, 0);
     });
 
     return () => {
@@ -127,7 +130,7 @@ export function WaveformConsole({
       }
       waveSurferRef.current = null;
     };
-  }, []);
+  }, [mediaElement]);
 
   useEffect(() => {
     const waveSurfer = waveSurferRef.current;
@@ -150,36 +153,41 @@ export function WaveformConsole({
       }
       setReady(false);
       setWaveformError(error instanceof Error ? error.message : String(error));
-      onTransportChangeRef.current(false);
+      onTransportChangeRef.current(false, 0);
     });
   }, [track?.audio_url, track?.track_id]);
 
   const duration = analysis?.duration_seconds ?? track?.duration_seconds ?? 0;
   const markerDuration = duration > 0 ? duration : 1;
-  const section = analysis ? activeSection(analysis.sections, currentTime) : null;
-
+  const activePhrase =
+    schedule?.phrases.find((phrase) => currentTime >= phrase.start_seconds && currentTime < phrase.end_seconds) ?? null;
   return (
     <section className="rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(7,13,24,0.94),rgba(4,8,16,0.98))] p-6 shadow-[0_30px_80px_rgba(0,0,0,0.35)]">
       <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <div className="flex flex-wrap items-center gap-3">
-            <Badge>Waveform Console</Badge>
-            <Badge variant="muted">{track?.source ?? "no source"}</Badge>
-            <Badge variant="accent">{ready ? "Preview Ready" : track ? "Loading Preview" : "Waiting on Track"}</Badge>
+            <Badge>{compact ? "Performance Timeline" : "Waveform Console"}</Badge>
+            {schedule ? <Badge variant="muted">{schedule.phrase_count} phrases</Badge> : null}
+            {!compact ? <Badge variant="muted">{track?.source ?? "no source"}</Badge> : null}
+            {!compact ? <Badge variant="accent">{ready ? "Preview Ready" : track ? "Loading Preview" : "Waiting on Track"}</Badge> : null}
           </div>
-          <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">
-            {track ? `${track.title} - ${track.artist}` : "Select a track to inspect the waveform"}
-          </h2>
-          <p className="mt-3 max-w-3xl text-sm text-slate-300 sm:text-base">
-            The waveform is now the main playback surface. Beat markers, downbeats, and section boundaries are derived
-            from the backend analysis payload so this view stays aligned with the choreography timeline.
-          </p>
+          {!compact ? (
+            <>
+              <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">
+                {track ? `${track.title} - ${track.artist}` : "Select a track to inspect the waveform"}
+              </h2>
+              <p className="mt-3 max-w-3xl text-sm text-slate-300 sm:text-base">
+                The waveform is now the main playback surface. Beat markers, downbeats, and section boundaries are derived
+                from the backend analysis payload so this view stays aligned with the choreography timeline.
+              </p>
+            </>
+          ) : null}
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className={`grid gap-3 ${compact ? "sm:grid-cols-2" : "sm:grid-cols-3"}`}>
           <ConsoleStat label="Time" value={formatClock(currentTime)} />
           <ConsoleStat label="Duration" value={formatClock(duration)} />
-          <ConsoleStat label="Section" value={section?.label ?? "unknown"} />
+          {!compact ? <ConsoleStat label="Ready" value={ready ? "yes" : "loading"} /> : null}
         </div>
       </div>
 
@@ -188,13 +196,7 @@ export function WaveformConsole({
           <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
             <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-3 py-2">
               <Waves className="h-4 w-4 text-primary" />
-              {analysis ? `${analysis.waveform.bucket_count} waveform samples` : "Live audio preview"}
-            </span>
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-3 py-2">
-              {analysis ? `${analysis.beats.length} beats` : "No beat markers yet"}
-            </span>
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-3 py-2">
-              {analysis ? `${analysis.sections.length} sections` : "No sections yet"}
+              {schedule ? "Scheduler overlaid on audio timeline" : "Audio timeline"}
             </span>
           </div>
 
@@ -203,6 +205,14 @@ export function WaveformConsole({
               variant="secondary"
               disabled={!track?.audio_url || !ready}
               onClick={() => {
+                if (compact && mediaElement) {
+                  if (mediaElement.paused) {
+                    void mediaElement.play().catch(() => undefined);
+                  } else {
+                    mediaElement.pause();
+                  }
+                  return;
+                }
                 waveSurferRef.current?.playPause();
               }}
             >
@@ -213,10 +223,15 @@ export function WaveformConsole({
               variant="ghost"
               disabled={!track?.audio_url}
               onClick={() => {
-                waveSurferRef.current?.pause();
-                waveSurferRef.current?.setTime(0);
+                if (compact && mediaElement) {
+                  mediaElement.pause();
+                  mediaElement.currentTime = 0;
+                } else {
+                  waveSurferRef.current?.pause();
+                  waveSurferRef.current?.setTime(0);
+                }
                 onTimeChange(0);
-                onTransportChange(false);
+                onTransportChange(false, 0);
               }}
             >
               <Square className="mr-2 h-4 w-4" />
@@ -227,33 +242,65 @@ export function WaveformConsole({
 
         <div className="relative mt-6 overflow-hidden rounded-[24px] border border-white/10 bg-[linear-gradient(180deg,rgba(10,18,31,0.92),rgba(6,11,21,0.98))] px-4 py-5">
           <div className="pointer-events-none absolute inset-x-0 top-0 h-16 bg-[linear-gradient(180deg,rgba(126,190,255,0.14),transparent)]" />
-          <div className="pointer-events-none absolute inset-y-6 left-4 right-4 z-20">
-            {analysis?.sections.map((item, index) => {
-              const left = `${(item.start_seconds / markerDuration) * 100}%`;
-              const width = `${Math.max(1.5, ((item.end_seconds - item.start_seconds) / markerDuration) * 100)}%`;
-              return (
-                <div
-                  key={`${item.label}-${index}`}
-                  className="absolute inset-y-0 rounded-2xl border border-primary/15 bg-primary/[0.06]"
-                  style={{ left, width }}
-                >
-                  <span className="absolute left-3 top-3 rounded-full bg-black/55 px-2 py-1 text-[10px] uppercase tracking-[0.22em] text-slate-200">
-                    {item.label}
-                  </span>
-                </div>
-              );
-            })}
+          {schedule?.phrases.length ? (
+            <div className="pointer-events-none absolute inset-x-4 top-4 z-30">
+              <div className="rounded-[18px] border border-white/10 bg-black/45 p-2 shadow-[0_18px_40px_rgba(0,0,0,0.3)] backdrop-blur-sm">
+                <div className="relative h-14 overflow-hidden rounded-[14px] bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.01))]">
+                  {schedule.phrases.map((phrase) => {
+                    const left = `${(phrase.start_seconds / markerDuration) * 100}%`;
+                    const width = `${Math.max(3, ((phrase.end_seconds - phrase.start_seconds) / markerDuration) * 100)}%`;
+                    const active = phrase.phrase_id === activePhrase?.phrase_id;
+                    const modeClass =
+                      phrase.execution_mode === "mirror"
+                        ? active
+                          ? "border-sky-200/70 bg-[linear-gradient(180deg,rgba(87,169,255,0.55),rgba(87,169,255,0.26))]"
+                          : "border-sky-300/30 bg-[linear-gradient(180deg,rgba(87,169,255,0.3),rgba(87,169,255,0.14))]"
+                        : active
+                          ? "border-white/70 bg-[linear-gradient(180deg,rgba(255,255,255,0.42),rgba(255,255,255,0.18))]"
+                          : "border-white/20 bg-[linear-gradient(180deg,rgba(255,255,255,0.2),rgba(255,255,255,0.08))]";
 
-            {analysis?.beats.map((beat, index) => {
-              const isDownbeat = analysis.downbeats.some((downbeat) => Math.abs(downbeat - beat) < 0.03);
-              return (
-                <div
-                  key={`beat-${index}`}
-                  className={isDownbeat ? "absolute inset-y-0 w-px bg-white/60" : "absolute inset-y-4 w-px bg-primary/30"}
-                  style={{ left: `${(beat / markerDuration) * 100}%` }}
-                />
-              );
-            })}
+                    return (
+                      <div
+                        key={phrase.phrase_id}
+                        className={`absolute top-1/2 flex h-10 -translate-y-1/2 items-center overflow-hidden rounded-[12px] border px-3 ${modeClass}`}
+                        style={{ left, width }}
+                      >
+                        <span className="truncate text-[10px] font-semibold uppercase tracking-[0.18em] text-white/95">
+                          {phrase.movement_id}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="mt-2 flex items-center justify-between px-1 text-[10px] uppercase tracking-[0.22em] text-slate-400">
+                  <span>Choreography Lane</span>
+                  <div className="flex items-center gap-3">
+                    <span className="inline-flex items-center gap-1">
+                      <span className="h-2 w-2 rounded-full bg-sky-300/80" />
+                      mirror
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <span className="h-2 w-2 rounded-full bg-white/80" />
+                      unison
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : null}
+          <div className="pointer-events-none absolute inset-y-6 left-4 right-4 z-20">
+            {!compact
+              ? analysis?.beats.map((beat, index) => {
+                  const isDownbeat = analysis.downbeats.some((downbeat) => Math.abs(downbeat - beat) < 0.03);
+                  return (
+                    <div
+                      key={`beat-${index}`}
+                      className={isDownbeat ? "absolute inset-y-0 w-px bg-white/60" : "absolute inset-y-4 w-px bg-primary/30"}
+                      style={{ left: `${(beat / markerDuration) * 100}%` }}
+                    />
+                  );
+                })
+              : null}
 
             <div
               className="absolute inset-y-0 w-0.5 bg-white shadow-[0_0_20px_rgba(255,255,255,0.55)]"

--- a/frontend/src/components/performance/performance-page.tsx
+++ b/frontend/src/components/performance/performance-page.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useRef, useState } from "react";
+import { Music2, Play, Search, Square } from "lucide-react";
+
+import type {
+  AnalysisStatusResponse,
+  AudioAnalysis,
+  AutonomousPerformanceState,
+  ChoreographySchedule,
+  TrackSummary,
+} from "@/lib/types";
+import { formatDuration } from "@/lib/analysis-view";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { WaveformConsole } from "@/components/music/waveform-console";
+
+export function PerformancePage({
+  searchQuery,
+  onSearchQueryChange,
+  onSearch,
+  searching,
+  searchError,
+  results,
+  currentTrack,
+  analysis,
+  analysisStatus,
+  schedule,
+  autonomy,
+  autonomyBusy,
+  currentTime,
+  transportPlaying,
+  onTimeChange,
+  onTransportChange,
+  onSelectTrack,
+  onStartAutonomy,
+  onStopAutonomy,
+}: {
+  searchQuery: string;
+  onSearchQueryChange: (value: string) => void;
+  onSearch: () => void;
+  searching: boolean;
+  searchError: string | null;
+  results: TrackSummary[];
+  currentTrack: TrackSummary | null;
+  analysis: AudioAnalysis | null;
+  analysisStatus: AnalysisStatusResponse | null;
+  schedule: ChoreographySchedule | null;
+  autonomy: AutonomousPerformanceState;
+  autonomyBusy: boolean;
+  currentTime: number;
+  transportPlaying: boolean;
+  onTimeChange: (value: number) => void;
+  onTransportChange: (playing: boolean, positionSeconds?: number) => void;
+  onSelectTrack: (track: TrackSummary) => void;
+  onStartAutonomy: () => void;
+  onStopAutonomy: () => void;
+}) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [mediaElement, setMediaElement] = useState<HTMLAudioElement | null>(null);
+  const readyToDance = !!currentTrack && !!schedule && schedule.phrase_count > 0;
+  const currentStatus = analysisStatus?.status ?? currentTrack?.analysis_status ?? "none";
+  const showResults = searching || !currentTrack;
+
+  useEffect(() => {
+    if (audioRef.current && audioRef.current !== mediaElement) {
+      setMediaElement(audioRef.current);
+    }
+  }, [mediaElement]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    if (!currentTrack?.audio_url) {
+      audio.pause();
+      audio.currentTime = 0;
+      return;
+    }
+
+    if (audio.src !== currentTrack.audio_url) {
+      audio.src = currentTrack.audio_url;
+      audio.load();
+    }
+
+    if (transportPlaying) {
+      void audio.play().catch(() => undefined);
+      return;
+    }
+
+    audio.pause();
+    if (autonomy.status === "idle") {
+      audio.currentTime = 0;
+    }
+  }, [autonomy.status, currentTrack?.audio_url, transportPlaying]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) {
+      return;
+    }
+
+    const handleTimeUpdate = () => {
+      onTimeChange(audio.currentTime);
+    };
+
+    const handlePlay = () => {
+      onTransportChange(true, audio.currentTime);
+    };
+
+    const handlePause = () => {
+      onTransportChange(false, audio.currentTime);
+    };
+
+    const handleSeeked = () => {
+      onTimeChange(audio.currentTime);
+      onTransportChange(!audio.paused, audio.currentTime);
+    };
+
+    const handleEnded = () => {
+      onTimeChange(0);
+      onTransportChange(false, 0);
+      if (autonomy.status !== "idle") {
+        onStopAutonomy();
+      }
+    };
+
+    audio.addEventListener("timeupdate", handleTimeUpdate);
+    audio.addEventListener("play", handlePlay);
+    audio.addEventListener("pause", handlePause);
+    audio.addEventListener("seeked", handleSeeked);
+    audio.addEventListener("ended", handleEnded);
+
+    return () => {
+      audio.removeEventListener("timeupdate", handleTimeUpdate);
+      audio.removeEventListener("play", handlePlay);
+      audio.removeEventListener("pause", handlePause);
+      audio.removeEventListener("seeked", handleSeeked);
+      audio.removeEventListener("ended", handleEnded);
+    };
+  }, [autonomy.status, onStopAutonomy, onTimeChange, onTransportChange]);
+
+  return (
+    <section className="grid gap-6">
+      <audio
+        ref={(node) => {
+          audioRef.current = node;
+        }}
+        preload="auto"
+      />
+      <Card className="border-white/10 bg-[linear-gradient(180deg,rgba(8,15,29,0.96),rgba(4,9,18,0.98))]">
+        <CardContent className="p-6 sm:p-8">
+          <div className="grid gap-5 xl:grid-cols-[0.8fr_1.2fr] xl:items-start">
+            <div className="grid gap-4">
+              <form
+                className="flex flex-col gap-3 sm:flex-row"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  onSearch();
+                }}
+              >
+                <div className="relative flex-1">
+                  <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+                  <Input
+                    value={searchQuery}
+                    onChange={(event) => onSearchQueryChange(event.target.value)}
+                    placeholder="Search a track for autonomous playback"
+                    className="h-14 pl-11 pr-5 text-base"
+                  />
+                </div>
+                <Button type="submit" size="lg" className="sm:min-w-32" disabled={searching}>
+                  {searching ? "Searching..." : "Search"}
+                </Button>
+              </form>
+
+              {searchError ? <p className="mt-3 text-sm text-red-200">{searchError}</p> : null}
+
+              {showResults ? (
+                <div className="mt-4 grid gap-3">
+                  {results.slice(0, 6).map((track) => {
+                    const active = currentTrack?.track_id === track.track_id && currentTrack?.source === track.source;
+                    return (
+                      <button
+                        key={`${track.source}-${track.track_id}`}
+                        type="button"
+                        onClick={() => onSelectTrack(track)}
+                        className={`flex items-center justify-between gap-4 rounded-[24px] border px-4 py-4 text-left transition ${
+                          active
+                            ? "border-primary/40 bg-primary/10"
+                            : "border-white/10 bg-white/[0.03] hover:border-primary/30 hover:bg-white/[0.05]"
+                        }`}
+                      >
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-3">
+                            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+                              <Music2 className="h-4 w-4" />
+                            </div>
+                            <div className="min-w-0">
+                              <p className="truncate text-base font-semibold text-white">{track.title}</p>
+                              <p className="truncate text-sm text-slate-400">{track.artist}</p>
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="flex shrink-0 items-center gap-3">
+                          <Badge variant={track.source === "local" ? "accent" : "muted"}>{track.source}</Badge>
+                          <span className="text-sm text-slate-400">{formatDuration(track.duration_seconds)}</span>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="mt-4 rounded-[24px] border border-primary/25 bg-primary/[0.08] p-4">
+                  <p className="text-sm font-medium text-white">Locked on selected song</p>
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5">
+              <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+                <div className="min-w-0">
+                  <p className="truncate text-2xl font-semibold text-white">
+                    {currentTrack ? currentTrack.title : "No track selected"}
+                  </p>
+                  <p className="mt-1 truncate text-sm text-slate-400">
+                    {currentTrack ? `${currentTrack.artist} · ${currentTrack.source}` : "Select a track to prepare the dance."}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  <Button disabled={!readyToDance || autonomyBusy} onClick={onStartAutonomy}>
+                    <Play className="mr-2 h-4 w-4" />
+                    {autonomyBusy ? "Starting..." : "Start Dance"}
+                  </Button>
+                  <Button variant="ghost" disabled={autonomyBusy || autonomy.status === "idle"} onClick={onStopAutonomy}>
+                    <Square className="mr-2 h-4 w-4" />
+                    Stop
+                  </Button>
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <CompactChip label="analysis" value={currentStatus} />
+                <CompactChip label="bpm" value={analysis ? analysis.bpm.toFixed(1) : "--"} />
+                <CompactChip label="phrases" value={schedule ? `${schedule.phrase_count}` : "--"} />
+                <CompactChip label="status" value={autonomy.status} />
+                {schedule ? <CompactChip label="style" value={schedule.style_id} /> : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <WaveformConsole
+              track={currentTrack}
+              analysis={analysis}
+              schedule={schedule}
+              currentTime={currentTime}
+              transportPlaying={transportPlaying}
+              onTimeChange={onTimeChange}
+              onTransportChange={onTransportChange}
+              mediaElement={mediaElement}
+              compact
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+function CompactChip({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-2">
+      <span className="text-[10px] uppercase tracking-[0.22em] text-slate-400">{label}</span>
+      <span className="text-sm font-medium capitalize text-white">{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -159,6 +159,7 @@ export function setTransport(payload: {
   bpm: number;
   energy: number;
   playing: boolean;
+  position_seconds?: number;
 }) {
   return request<RobotState>("/api/transport", {
     method: "POST",


### PR DESCRIPTION
Closes #61.\n\n## Summary\n- make the browser audio element the authoritative playback clock on the Performance page\n- throttle song position heartbeats into the backend scheduler\n- simplify waveform transport handling in compact performance mode\n\n## Verification\n- python3 -m compileall backend/app\n- backend/.venv/bin/python -m unittest discover -s backend/tests -v\n- npm run build