### PR TITLE
refactor: simplify performance page layout

### DIFF
--- a/frontend/src/components/layout/app-navbar.tsx
+++ b/frontend/src/components/layout/app-navbar.tsx
@@ -1,7 +1,6 @@
 import { Menu, Music2, Radio, Sparkles, X } from "lucide-react";
 import { useState } from "react";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 export type AppView = "home" | "performance" | "analysis" | "movements" | "robot";
@@ -54,11 +53,6 @@ export function AppNavbar({
               </Button>
             ))}
           </nav>
-
-          <div className="hidden items-center gap-3 lg:flex">
-            <Badge variant="muted">Responsive UI</Badge>
-            <Badge variant="accent">shadcn surface</Badge>
-          </div>
 
           <Button
             variant="ghost"

--- a/frontend/src/components/music/waveform-console.tsx
+++ b/frontend/src/components/music/waveform-console.tsx
@@ -162,17 +162,21 @@ export function WaveformConsole({
   const activePhrase =
     schedule?.phrases.find((phrase) => currentTime >= phrase.start_seconds && currentTime < phrase.end_seconds) ?? null;
   return (
-    <section className="rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(7,13,24,0.94),rgba(4,8,16,0.98))] p-6 shadow-[0_30px_80px_rgba(0,0,0,0.35)]">
+    <section
+      className={`rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(7,13,24,0.94),rgba(4,8,16,0.98))] shadow-[0_30px_80px_rgba(0,0,0,0.35)] ${
+        compact ? "overflow-hidden p-0" : "p-6"
+      }`}
+    >
       <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
-        <div>
-          <div className="flex flex-wrap items-center gap-3">
-            <Badge>{compact ? "Performance Timeline" : "Waveform Console"}</Badge>
-            {schedule ? <Badge variant="muted">{schedule.phrase_count} phrases</Badge> : null}
-            {!compact ? <Badge variant="muted">{track?.source ?? "no source"}</Badge> : null}
-            {!compact ? <Badge variant="accent">{ready ? "Preview Ready" : track ? "Loading Preview" : "Waiting on Track"}</Badge> : null}
-          </div>
-          {!compact ? (
-            <>
+        {compact ? null : (
+          <>
+            <div>
+              <div className="flex flex-wrap items-center gap-3">
+                <Badge>Waveform Console</Badge>
+                {schedule ? <Badge variant="muted">{schedule.phrase_count} phrases</Badge> : null}
+                <Badge variant="muted">{track?.source ?? "no source"}</Badge>
+                <Badge variant="accent">{ready ? "Preview Ready" : track ? "Loading Preview" : "Waiting on Track"}</Badge>
+              </div>
               <h2 className="mt-4 text-3xl font-semibold text-white sm:text-4xl">
                 {track ? `${track.title} - ${track.artist}` : "Select a track to inspect the waveform"}
               </h2>
@@ -180,30 +184,45 @@ export function WaveformConsole({
                 The waveform is now the main playback surface. Beat markers, downbeats, and section boundaries are derived
                 from the backend analysis payload so this view stays aligned with the choreography timeline.
               </p>
-            </>
-          ) : null}
-        </div>
+            </div>
 
-        <div className={`grid gap-3 ${compact ? "sm:grid-cols-2" : "sm:grid-cols-3"}`}>
-          <ConsoleStat label="Time" value={formatClock(currentTime)} />
-          <ConsoleStat label="Duration" value={formatClock(duration)} />
-          {!compact ? <ConsoleStat label="Ready" value={ready ? "yes" : "loading"} /> : null}
-        </div>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <ConsoleStat label="Time" value={formatClock(currentTime)} />
+              <ConsoleStat label="Duration" value={formatClock(duration)} />
+              <ConsoleStat label="Ready" value={ready ? "yes" : "loading"} />
+            </div>
+          </>
+        )}
       </div>
 
-      <div className="mt-6 rounded-[28px] border border-white/10 bg-black/25 p-5">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-3 py-2">
-              <Waves className="h-4 w-4 text-primary" />
-              {schedule ? "Scheduler overlaid on audio timeline" : "Audio timeline"}
-            </span>
-          </div>
+      <div className={`${compact ? "" : "mt-6 rounded-[28px] border border-white/10 bg-black/25 p-5"}`}>
+        <div className={`flex flex-wrap items-center justify-between gap-3 ${compact ? "border-b border-white/10 px-5 py-4 sm:px-6" : ""}`}>
+          {compact ? (
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-primary/20 bg-primary/10 text-primary">
+                <Waves className="h-4 w-4" />
+              </span>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-white">{track?.title ?? "Performance timeline"}</p>
+                <p className="truncate text-xs uppercase tracking-[0.18em] text-slate-400">
+                  {schedule ? `${schedule.phrase_count} phrases programmed` : "timeline waiting on schedule"}
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-3 py-2">
+                <Waves className="h-4 w-4 text-primary" />
+                {schedule ? "Scheduler overlaid on audio timeline" : "Audio timeline"}
+              </span>
+            </div>
+          )}
 
-          <div className="flex flex-wrap items-center gap-3">
+          <div className="flex flex-wrap items-center gap-2">
             <Button
               variant="secondary"
               disabled={!track?.audio_url || !ready}
+              className={compact ? "rounded-full px-4" : undefined}
               onClick={() => {
                 if (compact && mediaElement) {
                   if (mediaElement.paused) {
@@ -222,6 +241,7 @@ export function WaveformConsole({
             <Button
               variant="ghost"
               disabled={!track?.audio_url}
+              className={compact ? "rounded-full px-4" : undefined}
               onClick={() => {
                 if (compact && mediaElement) {
                   mediaElement.pause();
@@ -240,10 +260,16 @@ export function WaveformConsole({
           </div>
         </div>
 
-        <div className="relative mt-6 overflow-hidden rounded-[24px] border border-white/10 bg-[linear-gradient(180deg,rgba(10,18,31,0.92),rgba(6,11,21,0.98))] px-4 py-5">
+        <div
+          className={`relative overflow-hidden ${
+            compact
+              ? "bg-[linear-gradient(180deg,rgba(10,18,31,0.98),rgba(5,9,17,1))] px-5 py-5 sm:px-6"
+              : "mt-6 rounded-[24px] border border-white/10 bg-[linear-gradient(180deg,rgba(10,18,31,0.92),rgba(6,11,21,0.98))] px-4 py-5"
+          }`}
+        >
           <div className="pointer-events-none absolute inset-x-0 top-0 h-16 bg-[linear-gradient(180deg,rgba(126,190,255,0.14),transparent)]" />
           {schedule?.phrases.length ? (
-            <div className="pointer-events-none absolute inset-x-4 top-4 z-30">
+            <div className={`pointer-events-none absolute z-30 ${compact ? "inset-x-5 top-5 sm:inset-x-6" : "inset-x-4 top-4"}`}>
               <div className="rounded-[18px] border border-white/10 bg-black/45 p-2 shadow-[0_18px_40px_rgba(0,0,0,0.3)] backdrop-blur-sm">
                 <div className="relative h-14 overflow-hidden rounded-[14px] bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.01))]">
                   {schedule.phrases.map((phrase) => {
@@ -288,7 +314,7 @@ export function WaveformConsole({
               </div>
             </div>
           ) : null}
-          <div className="pointer-events-none absolute inset-y-6 left-4 right-4 z-20">
+          <div className={`pointer-events-none absolute inset-y-6 z-20 ${compact ? "left-5 right-5 sm:left-6 sm:right-6" : "left-4 right-4"}`}>
             {!compact
               ? analysis?.beats.map((beat, index) => {
                   const isDownbeat = analysis.downbeats.some((downbeat) => Math.abs(downbeat - beat) < 0.03);
@@ -311,7 +337,7 @@ export function WaveformConsole({
           <div ref={containerRef} className="relative z-10 min-h-[220px]" />
         </div>
 
-        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-400">
+        <div className={`flex flex-wrap items-center justify-between gap-3 text-sm text-slate-400 ${compact ? "border-t border-white/10 px-5 py-4 sm:px-6" : "mt-4"}`}>
           <div className="flex flex-wrap items-center gap-4">
             <span>0:00</span>
             <div className="h-px w-24 bg-white/10 sm:w-40" />

--- a/frontend/src/components/performance/performance-page.tsx
+++ b/frontend/src/components/performance/performance-page.tsx
@@ -11,7 +11,6 @@ import type {
 import { formatDuration } from "@/lib/analysis-view";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { WaveformConsole } from "@/components/music/waveform-console";
 
@@ -61,6 +60,12 @@ export function PerformancePage({
   const readyToDance = !!currentTrack && !!schedule && schedule.phrase_count > 0;
   const currentStatus = analysisStatus?.status ?? currentTrack?.analysis_status ?? "none";
   const showResults = searching || !currentTrack;
+  const summaryItems = [
+    { label: "status", value: currentStatus },
+    { label: "bpm", value: analysis ? analysis.bpm.toFixed(1) : "--" },
+    { label: "phrases", value: schedule ? String(schedule.phrase_count) : "--" },
+    { label: "style", value: schedule?.style_id ?? "--" },
+  ];
 
   useEffect(() => {
     if (audioRef.current && audioRef.current !== mediaElement) {
@@ -150,12 +155,12 @@ export function PerformancePage({
         }}
         preload="auto"
       />
-      <Card className="border-white/10 bg-[linear-gradient(180deg,rgba(8,15,29,0.96),rgba(4,9,18,0.98))]">
-        <CardContent className="p-6 sm:p-8">
-          <div className="grid gap-5 xl:grid-cols-[0.8fr_1.2fr] xl:items-start">
-            <div className="grid gap-4">
+      <div className="grid gap-6">
+        <div className="rounded-[32px] border border-white/10 bg-[linear-gradient(180deg,rgba(8,15,29,0.96),rgba(4,9,18,0.98))] px-5 py-5 shadow-[0_30px_80px_rgba(0,0,0,0.35)] sm:px-6">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
               <form
-                className="flex flex-col gap-3 sm:flex-row"
+                className="flex flex-1 flex-col gap-3 sm:flex-row"
                 onSubmit={(event) => {
                   event.preventDefault();
                   onSearch();
@@ -166,61 +171,56 @@ export function PerformancePage({
                   <Input
                     value={searchQuery}
                     onChange={(event) => onSearchQueryChange(event.target.value)}
-                    placeholder="Search a track for autonomous playback"
-                    className="h-14 pl-11 pr-5 text-base"
+                    placeholder="Select a song and start the performance"
+                    className="h-13 rounded-full border-white/10 bg-black/20 pl-11 pr-5 text-base"
                   />
                 </div>
-                <Button type="submit" size="lg" className="sm:min-w-32" disabled={searching}>
+                <Button type="submit" size="lg" className="rounded-full px-6 sm:min-w-28" disabled={searching}>
                   {searching ? "Searching..." : "Search"}
                 </Button>
               </form>
 
-              {searchError ? <p className="mt-3 text-sm text-red-200">{searchError}</p> : null}
-
-              {showResults ? (
-                <div className="mt-4 grid gap-3">
-                  {results.slice(0, 6).map((track) => {
-                    const active = currentTrack?.track_id === track.track_id && currentTrack?.source === track.source;
-                    return (
-                      <button
-                        key={`${track.source}-${track.track_id}`}
-                        type="button"
-                        onClick={() => onSelectTrack(track)}
-                        className={`flex items-center justify-between gap-4 rounded-[24px] border px-4 py-4 text-left transition ${
-                          active
-                            ? "border-primary/40 bg-primary/10"
-                            : "border-white/10 bg-white/[0.03] hover:border-primary/30 hover:bg-white/[0.05]"
-                        }`}
-                      >
-                        <div className="min-w-0">
-                          <div className="flex items-center gap-3">
-                            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/15 text-primary">
-                              <Music2 className="h-4 w-4" />
-                            </div>
-                            <div className="min-w-0">
-                              <p className="truncate text-base font-semibold text-white">{track.title}</p>
-                              <p className="truncate text-sm text-slate-400">{track.artist}</p>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="flex shrink-0 items-center gap-3">
-                          <Badge variant={track.source === "local" ? "accent" : "muted"}>{track.source}</Badge>
-                          <span className="text-sm text-slate-400">{formatDuration(track.duration_seconds)}</span>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              ) : (
-                <div className="mt-4 rounded-[24px] border border-primary/25 bg-primary/[0.08] p-4">
-                  <p className="text-sm font-medium text-white">Locked on selected song</p>
-                </div>
-              )}
+              <div className="flex flex-wrap gap-2">
+                <Button className="rounded-full px-5" disabled={!readyToDance || autonomyBusy} onClick={onStartAutonomy}>
+                  <Play className="mr-2 h-4 w-4" />
+                  {autonomyBusy ? "Starting..." : "Start Dance"}
+                </Button>
+                <Button variant="ghost" className="rounded-full px-5" disabled={autonomyBusy || autonomy.status === "idle"} onClick={onStopAutonomy}>
+                  <Square className="mr-2 h-4 w-4" />
+                  Stop
+                </Button>
+              </div>
             </div>
 
-            <div className="rounded-[28px] border border-white/10 bg-white/[0.04] p-5">
-              <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+            {searchError ? <p className="text-sm text-red-200">{searchError}</p> : null}
+
+            {showResults ? (
+              <div className="grid gap-2">
+                {results.slice(0, 5).map((track) => (
+                  <button
+                    key={`${track.source}-${track.track_id}`}
+                    type="button"
+                    onClick={() => onSelectTrack(track)}
+                    className="flex items-center justify-between gap-4 rounded-[22px] border border-white/10 bg-white/[0.03] px-4 py-3 text-left transition hover:border-primary/30 hover:bg-white/[0.05]"
+                  >
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+                        <Music2 className="h-4 w-4" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-white">{track.title}</p>
+                        <p className="truncate text-xs text-slate-400">{track.artist}</p>
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-3">
+                      <Badge variant={track.source === "local" ? "accent" : "muted"}>{track.source}</Badge>
+                      <span className="text-xs text-slate-400">{formatDuration(track.duration_seconds)}</span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                 <div className="min-w-0">
                   <p className="truncate text-2xl font-semibold text-white">
                     {currentTrack ? currentTrack.title : "No track selected"}
@@ -229,43 +229,29 @@ export function PerformancePage({
                     {currentTrack ? `${currentTrack.artist} · ${currentTrack.source}` : "Select a track to prepare the dance."}
                   </p>
                 </div>
-                <div className="flex flex-wrap gap-3">
-                  <Button disabled={!readyToDance || autonomyBusy} onClick={onStartAutonomy}>
-                    <Play className="mr-2 h-4 w-4" />
-                    {autonomyBusy ? "Starting..." : "Start Dance"}
-                  </Button>
-                  <Button variant="ghost" disabled={autonomyBusy || autonomy.status === "idle"} onClick={onStopAutonomy}>
-                    <Square className="mr-2 h-4 w-4" />
-                    Stop
-                  </Button>
+                <div className="flex flex-wrap gap-2">
+                  {summaryItems.map((item) => (
+                    <CompactChip key={item.label} label={item.label} value={item.value} />
+                  ))}
+                  <CompactChip label="dance" value={autonomy.status} />
                 </div>
               </div>
-
-              <div className="mt-4 flex flex-wrap gap-2">
-                <CompactChip label="analysis" value={currentStatus} />
-                <CompactChip label="bpm" value={analysis ? analysis.bpm.toFixed(1) : "--"} />
-                <CompactChip label="phrases" value={schedule ? `${schedule.phrase_count}` : "--"} />
-                <CompactChip label="status" value={autonomy.status} />
-                {schedule ? <CompactChip label="style" value={schedule.style_id} /> : null}
-              </div>
-            </div>
+            )}
           </div>
+        </div>
 
-          <div className="mt-6">
-            <WaveformConsole
-              track={currentTrack}
-              analysis={analysis}
-              schedule={schedule}
-              currentTime={currentTime}
-              transportPlaying={transportPlaying}
-              onTimeChange={onTimeChange}
-              onTransportChange={onTransportChange}
-              mediaElement={mediaElement}
-              compact
-            />
-          </div>
-        </CardContent>
-      </Card>
+        <WaveformConsole
+          track={currentTrack}
+          analysis={analysis}
+          schedule={schedule}
+          currentTime={currentTime}
+          transportPlaying={transportPlaying}
+          onTimeChange={onTimeChange}
+          onTransportChange={onTransportChange}
+          mediaElement={mediaElement}
+          compact
+        />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Closes #63.\n\n## Summary\n- flatten the Performance page into a cleaner search-and-stage layout\n- reduce compact waveform chrome so the playback stage is the main surface\n- remove the extra navbar badges on desktop\n\n## Verification\n- npm run build